### PR TITLE
[#3] 선착순 쿠폰 발급 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,5 @@ out/
 
 ### VS Code ###
 .vscode/
+
+spy.log

--- a/build.gradle
+++ b/build.gradle
@@ -52,6 +52,9 @@ dependencies {
     // RestDocs
     asciidoctorExt 'org.springframework.restdocs:spring-restdocs-asciidoctor'
     testImplementation 'org.springframework.restdocs:spring-restdocs-mockmvc'
+
+    // p6spy
+    implementation "com.github.gavlyukovskiy:p6spy-spring-boot-starter:1.9.1"
 }
 
 tasks.named('test') {

--- a/src/docs/asciidoc/api/coupon/coupon-apply.adoc
+++ b/src/docs/asciidoc/api/coupon/coupon-apply.adoc
@@ -1,0 +1,12 @@
+[[coupon-apply]]
+=== 쿠폰 발급
+
+==== HTTP Request
+
+include::{snippets}/coupon/apply/http-request.adoc[]
+include::{snippets}/coupon/apply/request-fields.adoc[]
+
+==== HTTP Response
+
+include::{snippets}/coupon/apply/http-response.adoc[]
+include::{snippets}/coupon/apply/response-fields.adoc[]

--- a/src/docs/asciidoc/api/coupon/coupon.adoc
+++ b/src/docs/asciidoc/api/coupon/coupon.adoc
@@ -2,5 +2,6 @@
 == Coupon API
 
 include::coupon-create.adoc[]
+include::coupon-apply.adoc[]
 
 

--- a/src/main/java/com/coffee_shop/coffeeshop/CoffeeshopApplication.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/CoffeeshopApplication.java
@@ -2,7 +2,9 @@ package com.coffee_shop.coffeeshop;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableScheduling
 @SpringBootApplication
 public class CoffeeshopApplication {
 

--- a/src/main/java/com/coffee_shop/coffeeshop/common/exception/BusinessException.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/common/exception/BusinessException.java
@@ -12,4 +12,9 @@ public class BusinessException extends RuntimeException {
 		super(errorCode.getMessage());
 		this.errorCode = errorCode;
 	}
+
+	public BusinessException(ErrorCode errorCode, String errorMessage) {
+		super(errorMessage);
+		this.errorCode = errorCode;
+	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/controller/coupon/api/CouponApplyController.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/controller/coupon/api/CouponApplyController.java
@@ -1,0 +1,33 @@
+package com.coffee_shop.coffeeshop.controller.coupon.api;
+
+import java.net.URI;
+import java.time.LocalDateTime;
+
+import jakarta.validation.Valid;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.coffee_shop.coffeeshop.common.dto.response.ApiResponse;
+import com.coffee_shop.coffeeshop.controller.coupon.api.dto.request.CouponApplyRequest;
+import com.coffee_shop.coffeeshop.service.coupon.CouponApplyService;
+
+import lombok.RequiredArgsConstructor;
+
+@RequestMapping("/api/coupons")
+@RequiredArgsConstructor
+@RestController
+public class CouponApplyController {
+	private final CouponApplyService couponApplyService;
+
+	@PostMapping("/apply")
+	public ResponseEntity<ApiResponse<Void>> issueCoupon(@RequestBody @Valid CouponApplyRequest request) {
+		couponApplyService.applyCoupon(request.toServiceRequest(), LocalDateTime.now());
+		return ResponseEntity.created(
+				URI.create("/api/users/" + request.getUserId() + "/coupons/" + request.getCouponId()))
+			.body(ApiResponse.created());
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/controller/coupon/api/dto/request/CouponApplyRequest.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/controller/coupon/api/dto/request/CouponApplyRequest.java
@@ -1,0 +1,37 @@
+package com.coffee_shop.coffeeshop.controller.coupon.api.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CouponApplyRequest {
+
+	@NotNull(message = "사용자 ID는 필수입니다.")
+	@Positive(message = "사용자 ID는 양수입니다.")
+	private Long userId;
+
+	@NotNull(message = "쿠폰 ID는 필수입니다.")
+	@Positive(message = "쿠폰 ID는 양수입니다.")
+	private Long couponId;
+
+	@Builder
+	private CouponApplyRequest(Long userId, Long couponId) {
+		this.userId = userId;
+		this.couponId = couponId;
+	}
+
+	public CouponApplyServiceRequest toServiceRequest() {
+		return CouponApplyServiceRequest.builder()
+			.userId(userId)
+			.couponId(couponId)
+			.build();
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/Coupon.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/Coupon.java
@@ -47,14 +47,17 @@ public class Coupon extends BaseTimeEntity {
 
 	private int maxIssueCount;
 
+	private int issuedCount;
+
 	@Builder
 	private Coupon(String name, CouponType type, int discountAmount, int minOrderAmount,
-		int maxIssueCount) {
+		int maxIssueCount, int issuedCount) {
 		this.name = name;
 		this.type = type;
 		this.discountAmount = convertDiscountAmount(type, discountAmount);
 		this.minOrderAmount = minOrderAmount;
 		this.maxIssueCount = maxIssueCount;
+		this.issuedCount = issuedCount;
 	}
 
 	private Cash convertDiscountAmount(CouponType type, int discountAmount) {
@@ -63,5 +66,17 @@ public class Coupon extends BaseTimeEntity {
 		}
 
 		return Cash.of(discountAmount);
+	}
+
+	public boolean canIssueCoupon() {
+		if (issuedCount < maxIssueCount) {
+			return true;
+		}
+
+		return false;
+	}
+
+	public void issueCoupon() {
+		issuedCount += 1;
 	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/CouponTransactionHistory.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/CouponTransactionHistory.java
@@ -1,0 +1,64 @@
+package com.coffee_shop.coffeeshop.domain.coupon;
+
+import static jakarta.persistence.FetchType.*;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import com.coffee_shop.coffeeshop.common.domain.BaseTimeEntity;
+import com.coffee_shop.coffeeshop.domain.order.Order;
+import com.coffee_shop.coffeeshop.domain.user.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "coupon_transaction_histories")
+public class CouponTransactionHistory extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = LAZY, optional = false)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = LAZY)
+	@JoinColumn(name = "order_id")
+	private Order order;
+
+	@ManyToOne(fetch = LAZY, optional = false)
+	@JoinColumn(name = "coupon_id")
+	private Coupon coupon;
+
+	@Column(nullable = false)
+	private LocalDateTime issueDateTime;
+
+	@Builder
+	private CouponTransactionHistory(User user, Order order, Coupon coupon, LocalDateTime issueDateTime) {
+		this.user = user;
+		this.order = order;
+		this.coupon = coupon;
+		this.issueDateTime = issueDateTime;
+	}
+
+	public static CouponTransactionHistory issueCoupon(User user, Coupon coupon, LocalDateTime issueDateTime) {
+		return CouponTransactionHistory.builder()
+			.user(user)
+			.coupon(coupon)
+			.issueDateTime(issueDateTime)
+			.build();
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/CouponTransactionHistoryRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/CouponTransactionHistoryRepository.java
@@ -1,0 +1,11 @@
+package com.coffee_shop.coffeeshop.domain.coupon;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.coffee_shop.coffeeshop.domain.user.User;
+
+public interface CouponTransactionHistoryRepository extends JpaRepository<CouponTransactionHistory, Long> {
+	Optional<CouponTransactionHistory> findByCouponAndUser(Coupon coupon, User user);
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/MessageQ.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/MessageQ.java
@@ -1,7 +1,7 @@
 package com.coffee_shop.coffeeshop.domain.coupon;
 
-import java.util.Queue;
-import java.util.concurrent.ConcurrentLinkedQueue;
+import java.util.Deque;
+import java.util.concurrent.ConcurrentLinkedDeque;
 
 import org.springframework.stereotype.Component;
 
@@ -10,18 +10,18 @@ import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
 @Component
 public class MessageQ {
 
-	private final Queue<CouponApplication> queue;
+	private final Deque<CouponApplication> queue;
 
 	public MessageQ() {
-		this.queue = new ConcurrentLinkedQueue<>();
+		this.queue = new ConcurrentLinkedDeque<>();
 	}
 
 	public void addMessage(CouponApplication message) {
-		queue.offer(message);
+		queue.add(message);
 	}
 
 	public CouponApplication takeMessage() {
-		return queue.poll();
+		return queue.removeFirst();
 	}
 
 	public boolean isEmpty() {

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/MessageQ.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/MessageQ.java
@@ -31,4 +31,8 @@ public class MessageQ {
 	public int size() {
 		return queue.size();
 	}
+
+	public void addFirst(CouponApplication couponApplication) {
+		queue.addFirst(couponApplication);
+	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/MessageQ.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/MessageQ.java
@@ -1,0 +1,34 @@
+package com.coffee_shop.coffeeshop.domain.coupon;
+
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedQueue;
+
+import org.springframework.stereotype.Component;
+
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
+
+@Component
+public class MessageQ {
+
+	private final Queue<CouponApplication> queue;
+
+	public MessageQ() {
+		this.queue = new ConcurrentLinkedQueue<>();
+	}
+
+	public void addMessage(CouponApplication message) {
+		queue.offer(message);
+	}
+
+	public CouponApplication takeMessage() {
+		return queue.poll();
+	}
+
+	public boolean isEmpty() {
+		return queue.isEmpty();
+	}
+
+	public int size() {
+		return queue.size();
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponConsumer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponConsumer.java
@@ -1,0 +1,5 @@
+package com.coffee_shop.coffeeshop.domain.coupon.consumer;
+
+public interface CouponConsumer {
+	void issueCoupon();
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumer.java
@@ -59,7 +59,7 @@ public class CouponMessageQConsumer implements CouponConsumer {
 				} catch (BusinessException e) {
 					log.info("쿠폰발급 실패 > " + e.getMessage());
 				} catch (Exception e) {
-					couponIssueFailHandler.retry(couponApplication, e);
+					couponIssueFailHandler.handleFail(couponApplication, e);
 				}
 			}
 		}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumer.java
@@ -1,0 +1,87 @@
+package com.coffee_shop.coffeeshop.domain.coupon.consumer;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.coffee_shop.coffeeshop.common.exception.BusinessException;
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.domain.user.UserRepository;
+import com.coffee_shop.coffeeshop.exception.ErrorCode;
+import com.coffee_shop.coffeeshop.service.coupon.CouponIssueFailHandler;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CouponMessageQConsumer implements CouponConsumer {
+	private final MessageQ messageQ;
+	private final UserRepository userRepository;
+	private final CouponRepository couponRepository;
+	private final CouponTransactionHistoryRepository couponTransactionHistoryRepository;
+	private final CouponIssueFailHandler couponIssueFailHandler;
+
+	@Override
+	@Transactional
+	@Scheduled(cron = "0/1 * * * * *")
+	public void issueCoupon() {
+		while (!messageQ.isEmpty()) {
+			//발급 신청이 존재하면 발급 처리
+			CouponApplication couponApplication = messageQ.takeMessage();
+
+			synchronized (this) {
+				try {
+					Coupon coupon = findCoupon(couponApplication.getCouponId());
+					User user = findUser(couponApplication.getUserId());
+
+					//발급할 수 있는 쿠폰개수를 확인한다.
+					if (!coupon.canIssueCoupon()) {
+						throw new BusinessException(ErrorCode.COUPON_LIMIT_REACHED);
+					}
+
+					//이미 발급된 쿠폰인지 확인
+					checkDuplicateIssuedCoupon(coupon, user);
+
+					//발급 count +1
+					coupon.issueCoupon();
+
+					//이력 저장
+					couponTransactionHistoryRepository.save(
+						CouponTransactionHistory.issueCoupon(user, coupon, couponApplication.getIssueDateTime()));
+				} catch (BusinessException e) {
+					log.info("쿠폰발급 실패 > " + e.getMessage());
+				} catch (Exception e) {
+					couponIssueFailHandler.retry(couponApplication, e);
+				}
+			}
+		}
+	}
+
+	private Coupon findCoupon(Long couponId) {
+		return couponRepository.findById(couponId)
+			.orElseThrow(
+				() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND, "Coupon Not Found, 쿠폰 ID : " + couponId));
+	}
+
+	private User findUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND, "User Not Found, 사용자 ID : " + userId));
+	}
+
+	private void checkDuplicateIssuedCoupon(Coupon coupon, User user) {
+		couponTransactionHistoryRepository.findByCouponAndUser(coupon, user)
+			.ifPresent(couponTransactionHistory -> {
+				throw new BusinessException(ErrorCode.COUPON_DUPLICATE_ISSUE,
+					ErrorCode.COUPON_DUPLICATE_ISSUE.getMessage() + " 사용자 ID, 이름 : " + user.getId() + ", "
+						+ user.getName());
+			});
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumer.java
@@ -2,18 +2,11 @@ package com.coffee_shop.coffeeshop.domain.coupon.consumer;
 
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
-import org.springframework.transaction.annotation.Transactional;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
-import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
-import com.coffee_shop.coffeeshop.domain.coupon.CouponRepository;
-import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
-import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
-import com.coffee_shop.coffeeshop.domain.user.User;
-import com.coffee_shop.coffeeshop.domain.user.UserRepository;
-import com.coffee_shop.coffeeshop.exception.ErrorCode;
 import com.coffee_shop.coffeeshop.service.coupon.CouponIssueFailHandler;
+import com.coffee_shop.coffeeshop.service.coupon.CouponIssueService;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
 
 import lombok.RequiredArgsConstructor;
@@ -24,64 +17,22 @@ import lombok.extern.slf4j.Slf4j;
 @Component
 public class CouponMessageQConsumer implements CouponConsumer {
 	private final MessageQ messageQ;
-	private final UserRepository userRepository;
-	private final CouponRepository couponRepository;
-	private final CouponTransactionHistoryRepository couponTransactionHistoryRepository;
 	private final CouponIssueFailHandler couponIssueFailHandler;
+	private final CouponIssueService couponIssueService;
 
 	@Override
-	@Transactional
 	@Scheduled(cron = "0/1 * * * * *")
-	public void issueCoupon() {
+	public synchronized void issueCoupon() {
 		while (!messageQ.isEmpty()) {
 			//발급 신청이 존재하면 발급 처리
 			CouponApplication couponApplication = messageQ.takeMessage();
-
-			synchronized (this) {
-				try {
-					Coupon coupon = findCoupon(couponApplication.getCouponId());
-					User user = findUser(couponApplication.getUserId());
-
-					//발급할 수 있는 쿠폰개수를 확인한다.
-					if (!coupon.canIssueCoupon()) {
-						throw new BusinessException(ErrorCode.COUPON_LIMIT_REACHED);
-					}
-
-					//이미 발급된 쿠폰인지 확인
-					checkDuplicateIssuedCoupon(coupon, user);
-
-					//발급 count +1
-					coupon.issueCoupon();
-
-					//이력 저장
-					couponTransactionHistoryRepository.save(
-						CouponTransactionHistory.issueCoupon(user, coupon, couponApplication.getIssueDateTime()));
-				} catch (BusinessException e) {
-					log.info("쿠폰발급 실패 > " + e.getMessage());
-				} catch (Exception e) {
-					couponIssueFailHandler.handleFail(couponApplication, e);
-				}
+			try {
+				couponIssueService.issueCoupon(couponApplication);
+			} catch (BusinessException e) {
+				log.info("쿠폰발급 실패 > " + e.getMessage());
+			} catch (Exception e) {
+				couponIssueFailHandler.handleFail(couponApplication, e);
 			}
 		}
-	}
-
-	private Coupon findCoupon(Long couponId) {
-		return couponRepository.findById(couponId)
-			.orElseThrow(
-				() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND, "Coupon Not Found, 쿠폰 ID : " + couponId));
-	}
-
-	private User findUser(Long userId) {
-		return userRepository.findById(userId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND, "User Not Found, 사용자 ID : " + userId));
-	}
-
-	private void checkDuplicateIssuedCoupon(Coupon coupon, User user) {
-		couponTransactionHistoryRepository.findByCouponAndUser(coupon, user)
-			.ifPresent(couponTransactionHistory -> {
-				throw new BusinessException(ErrorCode.COUPON_DUPLICATE_ISSUE,
-					ErrorCode.COUPON_DUPLICATE_ISSUE.getMessage() + " 사용자 ID, 이름 : " + user.getId() + ", "
-						+ user.getName());
-			});
 	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponMessageQProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponMessageQProducer.java
@@ -19,6 +19,7 @@ public class CouponMessageQProducer implements CouponProducer {
 
 	@Override
 	public void applyCoupon(User user, Coupon coupon, LocalDateTime issueDateTime) {
-		messageQ.addMessage(new CouponApplication(user.getId(), coupon.getId(), issueDateTime));
+		CouponApplication couponApplication = CouponApplication.createCouponApplication(user, coupon, issueDateTime);
+		messageQ.addMessage(couponApplication);
 	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponMessageQProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponMessageQProducer.java
@@ -1,0 +1,24 @@
+package com.coffee_shop.coffeeshop.domain.coupon.producer;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Component;
+
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Component
+public class CouponMessageQProducer implements CouponProducer {
+
+	private final MessageQ messageQ;
+
+	@Override
+	public void applyCoupon(User user, Coupon coupon, LocalDateTime issueDateTime) {
+		messageQ.addMessage(new CouponApplication(user.getId(), coupon.getId(), issueDateTime));
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponProducer.java
@@ -1,0 +1,10 @@
+package com.coffee_shop.coffeeshop.domain.coupon.producer;
+
+import java.time.LocalDateTime;
+
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.user.User;
+
+public interface CouponProducer {
+	void applyCoupon(User user, Coupon coupon, LocalDateTime issueDateTime);
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/exception/ErrorCode.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/exception/ErrorCode.java
@@ -18,7 +18,9 @@ public enum ErrorCode {
 	MISSING_REQUEST_PARAM(HttpStatus.BAD_REQUEST, "MISSING_REQUEST_PARAM", "요청 파라미터를 누락하였습니다."),
 
 	ENTITY_NOT_FOUND(HttpStatus.NOT_FOUND, "ENTITY_NOT_FOUND", "해당 데이터를 찾을 수 없습니다."),
-	INVALID_DISCOUNT_PERCENTAGE(HttpStatus.BAD_REQUEST, "INVALID_DISCOUNT_PERCENTAGE", "할인율은 1~100까지 입력가능합니다.");
+	INVALID_DISCOUNT_PERCENTAGE(HttpStatus.BAD_REQUEST, "INVALID_DISCOUNT_PERCENTAGE", "할인율은 1~100까지 입력가능합니다."),
+	COUPON_LIMIT_REACHED(HttpStatus.BAD_REQUEST, "INVALID_DISCOUNT_PERCENTAGE", "쿠폰이 모두 소진되어 발급할 수 없습니다."),
+	COUPON_DUPLICATE_ISSUE(HttpStatus.BAD_REQUEST, "INVALID_DISCOUNT_PERCENTAGE", "이미 발급된 쿠폰입니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponApplyService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponApplyService.java
@@ -19,7 +19,7 @@ import lombok.RequiredArgsConstructor;
 @Transactional
 @RequiredArgsConstructor
 @Service
-public class CouponIssueService {
+public class CouponApplyService {
 	private final UserRepository userRepository;
 	private final CouponRepository couponRepository;
 	private final CouponProducer couponMessageQProducer;

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponApplyService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponApplyService.java
@@ -13,6 +13,7 @@ import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponProducer;
 import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.exception.ErrorCode;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
 
 import lombok.RequiredArgsConstructor;
 
@@ -25,9 +26,9 @@ public class CouponApplyService {
 	private final CouponProducer couponMessageQProducer;
 	private final CouponTransactionHistoryRepository couponTransactionHistoryRepository;
 
-	public void applyCoupon(Long userId, Long couponId, LocalDateTime issueDateTime) {
-		User user = findUser(userId);
-		Coupon coupon = findCoupon(couponId);
+	public void applyCoupon(CouponApplyServiceRequest request, LocalDateTime issueDateTime) {
+		User user = findUser(request.getUserId());
+		Coupon coupon = findCoupon(request.getCouponId());
 
 		//발급할 수 있는 쿠폰개수를 확인한다.
 		if (!coupon.canIssueCoupon()) {

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueFailHandler.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueFailHandler.java
@@ -20,10 +20,11 @@ public class CouponIssueFailHandler {
 	public void handleFail(CouponApplication couponApplication, Exception e) {
 		couponApplication.addException(e);
 		couponApplication.increaseFailCount();
+
 		if (couponApplication.getFailCount() >= MAX_FAIL_COUNT) {
 			handleTooManyFails(couponApplication);
 		} else {
-			messageQ.addMessage(couponApplication);
+			messageQ.addFirst(couponApplication);
 		}
 	}
 

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueFailHandler.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueFailHandler.java
@@ -14,13 +14,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Component
 public class CouponIssueFailHandler {
-	private static final int MAX_RETRY_COUNT = 3;
+	private static final int MAX_FAIL_COUNT = 3;
 	private final MessageQ messageQ;
 
 	public void handleFail(CouponApplication couponApplication, Exception e) {
 		couponApplication.addException(e);
 		couponApplication.increaseFailCount();
-		if (couponApplication.getFailCount() >= MAX_RETRY_COUNT) {
+		if (couponApplication.getFailCount() >= MAX_FAIL_COUNT) {
 			handleTooManyFails(couponApplication);
 		} else {
 			messageQ.addMessage(couponApplication);
@@ -28,7 +28,7 @@ public class CouponIssueFailHandler {
 	}
 
 	private void handleTooManyFails(CouponApplication couponApplication) {
-		log.info("최대 실패 횟수 (" + MAX_RETRY_COUNT + ")를 초과하였습니다. 실패 횟수 : " + couponApplication.getFailCount());
+		log.info("최대 실패 횟수 " + MAX_FAIL_COUNT + "회를 초과하였습니다. 실패 횟수 : " + couponApplication.getFailCount());
 		log.info("---------------------- 예외 리스트 START ----------------------");
 		List<Exception> exceptionList = couponApplication.getExceptionList();
 		log.info("실패한 메시지 : " + couponApplication);

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueFailHandler.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueFailHandler.java
@@ -1,0 +1,42 @@
+package com.coffee_shop.coffeeshop.service.coupon;
+
+import java.util.List;
+
+import org.springframework.stereotype.Component;
+
+import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CouponIssueFailHandler {
+	private static final int MAX_RETRY_COUNT = 3;
+	private final MessageQ messageQ;
+
+	public void handleFail(CouponApplication couponApplication, Exception e) {
+		couponApplication.addException(e);
+		couponApplication.increaseFailCount();
+		if (couponApplication.getFailCount() >= MAX_RETRY_COUNT) {
+			handleTooManyFails(couponApplication);
+		} else {
+			messageQ.addMessage(couponApplication);
+		}
+	}
+
+	private void handleTooManyFails(CouponApplication couponApplication) {
+		log.info("최대 실패 횟수 (" + MAX_RETRY_COUNT + ")를 초과하였습니다. 실패 횟수 : " + couponApplication.getFailCount());
+		log.info("---------------------- 예외 리스트 START ----------------------");
+		List<Exception> exceptionList = couponApplication.getExceptionList();
+		log.info("실패한 메시지 : " + couponApplication);
+		for (int i = 0; i < couponApplication.getExceptionList().size(); i++) {
+			Exception e = exceptionList.get(i);
+			e.printStackTrace();
+			log.info("----------------------------------");
+		}
+		log.info("---------------------- 예외 리스트 END ----------------------");
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueService.java
@@ -1,0 +1,62 @@
+package com.coffee_shop.coffeeshop.service.coupon;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.coffee_shop.coffeeshop.common.exception.BusinessException;
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponProducer;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.domain.user.UserRepository;
+import com.coffee_shop.coffeeshop.exception.ErrorCode;
+
+import lombok.RequiredArgsConstructor;
+
+@Transactional
+@RequiredArgsConstructor
+@Service
+public class CouponIssueService {
+	private final UserRepository userRepository;
+	private final CouponRepository couponRepository;
+	private final CouponProducer couponMessageQProducer;
+	private final CouponTransactionHistoryRepository couponTransactionHistoryRepository;
+
+	public void applyCoupon(Long userId, Long couponId, LocalDateTime issueDateTime) {
+		User user = findUser(userId);
+		Coupon coupon = findCoupon(couponId);
+
+		//발급할 수 있는 쿠폰개수를 확인한다.
+		if (!coupon.canIssueCoupon()) {
+			throw new BusinessException(ErrorCode.COUPON_LIMIT_REACHED);
+		}
+
+		//이미 발급된 쿠폰인지 확인
+		checkDuplicateIssuedCoupon(coupon, user);
+
+		//발급 신청 -> 큐에 넣기
+		couponMessageQProducer.applyCoupon(user, coupon, issueDateTime);
+	}
+
+	private void checkDuplicateIssuedCoupon(Coupon coupon, User user) {
+		couponTransactionHistoryRepository.findByCouponAndUser(coupon, user)
+			.ifPresent(couponTransactionHistory -> {
+				throw new BusinessException(ErrorCode.COUPON_DUPLICATE_ISSUE,
+					ErrorCode.COUPON_DUPLICATE_ISSUE.getMessage() + " 사용자 ID, 이름 : " + user.getId() + ", "
+						+ user.getName());
+			});
+	}
+
+	private Coupon findCoupon(Long couponId) {
+		return couponRepository.findById(couponId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+	}
+
+	private User findUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueService.java
@@ -1,0 +1,67 @@
+package com.coffee_shop.coffeeshop.service.coupon;
+
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.coffee_shop.coffeeshop.common.exception.BusinessException;
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.domain.user.UserRepository;
+import com.coffee_shop.coffeeshop.exception.ErrorCode;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Component
+public class CouponIssueService {
+	private final UserRepository userRepository;
+	private final CouponRepository couponRepository;
+	private final CouponTransactionHistoryRepository couponTransactionHistoryRepository;
+
+	@Transactional
+	public void issueCoupon(CouponApplication couponApplication) {
+		Coupon coupon = findCoupon(couponApplication.getCouponId());
+		User user = findUser(couponApplication.getUserId());
+
+		//발급할 수 있는 쿠폰개수를 확인한다.
+		if (!coupon.canIssueCoupon()) {
+			throw new BusinessException(ErrorCode.COUPON_LIMIT_REACHED);
+		}
+
+		//이미 발급된 쿠폰인지 확인
+		checkDuplicateIssuedCoupon(coupon, user);
+
+		//발급 count +1
+		coupon.issueCoupon();
+
+		//이력 저장
+		couponTransactionHistoryRepository.save(
+			CouponTransactionHistory.issueCoupon(user, coupon, couponApplication.getIssueDateTime()));
+	}
+
+	private Coupon findCoupon(Long couponId) {
+		return couponRepository.findById(couponId)
+			.orElseThrow(
+				() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND, "Coupon Not Found, 쿠폰 ID : " + couponId));
+	}
+
+	private User findUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND, "User Not Found, 사용자 ID : " + userId));
+	}
+
+	private void checkDuplicateIssuedCoupon(Coupon coupon, User user) {
+		couponTransactionHistoryRepository.findByCouponAndUser(coupon, user)
+			.ifPresent(couponTransactionHistory -> {
+				throw new BusinessException(ErrorCode.COUPON_DUPLICATE_ISSUE,
+					ErrorCode.COUPON_DUPLICATE_ISSUE.getMessage() + " 사용자 ID, 이름 : " + user.getId() + ", "
+						+ user.getName());
+			});
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/dto/request/CouponApplication.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/dto/request/CouponApplication.java
@@ -28,4 +28,14 @@ public class CouponApplication {
 		failCount += 1;
 	}
 
+	@Override
+	public String toString() {
+		return "CouponApplication{" +
+			"userId=" + userId +
+			", couponId=" + couponId +
+			", issueDateTime=" + issueDateTime +
+			", failCount=" + failCount +
+			", exceptionList=" + exceptionList +
+			'}';
+	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/dto/request/CouponApplication.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/dto/request/CouponApplication.java
@@ -1,6 +1,8 @@
 package com.coffee_shop.coffeeshop.service.coupon.dto.request;
 
 import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
 
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
@@ -9,6 +11,21 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class CouponApplication {
 	private final Long userId;
+
 	private final Long couponId;
+
 	private final LocalDateTime issueDateTime;
+
+	private int failCount;
+
+	private List<Exception> exceptionList = new ArrayList<>();
+
+	public void addException(Exception e) {
+		exceptionList.add(e);
+	}
+
+	public void increaseFailCount() {
+		failCount += 1;
+	}
+
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/dto/request/CouponApplication.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/dto/request/CouponApplication.java
@@ -1,0 +1,14 @@
+package com.coffee_shop.coffeeshop.service.coupon.dto.request;
+
+import java.time.LocalDateTime;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+@Getter
+@RequiredArgsConstructor
+public class CouponApplication {
+	private final Long userId;
+	private final Long couponId;
+	private final LocalDateTime issueDateTime;
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/dto/request/CouponApplication.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/dto/request/CouponApplication.java
@@ -3,22 +3,44 @@ package com.coffee_shop.coffeeshop.service.coupon.dto.request;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.user.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
 import lombok.Getter;
-import lombok.RequiredArgsConstructor;
+import lombok.NoArgsConstructor;
 
 @Getter
-@RequiredArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
 public class CouponApplication {
-	private final Long userId;
+	private Long userId;
 
-	private final Long couponId;
+	private Long couponId;
 
-	private final LocalDateTime issueDateTime;
+	private LocalDateTime issueDateTime;
 
 	private int failCount;
 
 	private List<Exception> exceptionList = new ArrayList<>();
+
+	@Builder
+	private CouponApplication(Long userId, Long couponId, LocalDateTime issueDateTime, int failCount) {
+		this.userId = userId;
+		this.couponId = couponId;
+		this.issueDateTime = issueDateTime;
+		this.failCount = failCount;
+	}
+
+	public static CouponApplication createCouponApplication(User user, Coupon coupon, LocalDateTime issueDateTime) {
+		return CouponApplication.builder()
+			.userId(user.getId())
+			.couponId(coupon.getId())
+			.issueDateTime(issueDateTime)
+			.build();
+	}
 
 	public void addException(Exception e) {
 		exceptionList.add(e);
@@ -26,6 +48,23 @@ public class CouponApplication {
 
 	public void increaseFailCount() {
 		failCount += 1;
+	}
+
+	@Override
+	public boolean equals(Object o) {
+		if (this == o)
+			return true;
+		if (o == null || getClass() != o.getClass())
+			return false;
+		CouponApplication that = (CouponApplication)o;
+		return getFailCount() == that.getFailCount() && Objects.equals(getUserId(), that.getUserId())
+			&& Objects.equals(getCouponId(), that.getCouponId()) && Objects.equals(getIssueDateTime(),
+			that.getIssueDateTime());
+	}
+
+	@Override
+	public int hashCode() {
+		return Objects.hash(getUserId(), getCouponId(), getIssueDateTime(), getFailCount());
 	}
 
 	@Override

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/dto/request/CouponApplyServiceRequest.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/dto/request/CouponApplyServiceRequest.java
@@ -1,0 +1,21 @@
+package com.coffee_shop.coffeeshop.service.coupon.dto.request;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PRIVATE)
+public class CouponApplyServiceRequest {
+
+	private Long userId;
+
+	private Long couponId;
+
+	@Builder
+	private CouponApplyServiceRequest(Long userId, Long couponId) {
+		this.userId = userId;
+		this.couponId = couponId;
+	}
+}

--- a/src/test/java/com/coffee_shop/coffeeshop/controller/coupon/api/CouponApplyControllerTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/controller/coupon/api/CouponApplyControllerTest.java
@@ -1,0 +1,140 @@
+package com.coffee_shop.coffeeshop.controller.coupon.api;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+
+import com.coffee_shop.coffeeshop.controller.RestDocsSupport;
+import com.coffee_shop.coffeeshop.controller.coupon.api.dto.request.CouponApplyRequest;
+import com.coffee_shop.coffeeshop.docs.coupon.CouponDocumentation;
+import com.coffee_shop.coffeeshop.service.coupon.CouponApplyService;
+
+@WebMvcTest(controllers = CouponApplyController.class)
+class CouponApplyControllerTest extends RestDocsSupport {
+
+	@MockBean
+	protected CouponApplyService couponApplyService;
+
+	@DisplayName("쿠폰 발급 시 사용자 id는 필수값이다.")
+	@Test
+	void applyCouponWhenUserIdIsNull() throws Exception {
+		//given
+		CouponApplyRequest request = CouponApplyRequest.builder()
+			.couponId(1L)
+			.build();
+
+		//when //then
+		mockMvc.perform(
+				post("/api/coupons/apply")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"))
+			.andExpect(jsonPath("$.message").value("적절하지 않은 요청 값입니다."))
+			.andExpect(jsonPath("$.fieldErrors[0].field").value("userId"))
+			.andExpect(jsonPath("$.fieldErrors[0].message").value("사용자 ID는 필수입니다."));
+	}
+
+	@DisplayName("쿠폰 발급 시 사용자 id는 양수이다.")
+	@Test
+	void applyCouponWhenUserIdIsZero() throws Exception {
+		//given
+		CouponApplyRequest request = CouponApplyRequest.builder()
+			.userId(0L)
+			.couponId(1L)
+			.build();
+
+		//when //then
+		mockMvc.perform(
+				post("/api/coupons/apply")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"))
+			.andExpect(jsonPath("$.message").value("적절하지 않은 요청 값입니다."))
+			.andExpect(jsonPath("$.fieldErrors[0].field").value("userId"))
+			.andExpect(jsonPath("$.fieldErrors[0].message").value("사용자 ID는 양수입니다."));
+	}
+
+	@DisplayName("쿠폰 발급 시 쿠폰 id는 필수값이다.")
+	@Test
+	void applyCouponWhenCouponIdIsNull() throws Exception {
+		//given
+		CouponApplyRequest request = CouponApplyRequest.builder()
+			.userId(1L)
+			.build();
+
+		//when //then
+		mockMvc.perform(
+				post("/api/coupons/apply")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"))
+			.andExpect(jsonPath("$.message").value("적절하지 않은 요청 값입니다."))
+			.andExpect(jsonPath("$.fieldErrors[0].field").value("couponId"))
+			.andExpect(jsonPath("$.fieldErrors[0].message").value("쿠폰 ID는 필수입니다."));
+	}
+
+	@DisplayName("쿠폰 발급 시 쿠폰 id는 양수이다.")
+	@Test
+	void applyCouponWhenCouponIdIsZero() throws Exception {
+		//given
+		CouponApplyRequest request = CouponApplyRequest.builder()
+			.couponId(0L)
+			.userId(1L)
+			.build();
+
+		//when //then
+		mockMvc.perform(
+				post("/api/coupons/apply")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isBadRequest())
+			.andExpect(jsonPath("$.code").value("INVALID_INPUT_VALUE"))
+			.andExpect(jsonPath("$.message").value("적절하지 않은 요청 값입니다."))
+			.andExpect(jsonPath("$.fieldErrors[0].field").value("couponId"))
+			.andExpect(jsonPath("$.fieldErrors[0].message").value("쿠폰 ID는 양수입니다."));
+	}
+
+	@DisplayName("쿠폰을 생성한다.")
+	@Test
+	void applyCoupon() throws Exception {
+		//given
+		CouponApplyRequest request = CouponApplyRequest.builder()
+			.couponId(1L)
+			.userId(1L)
+			.build();
+
+		doNothing().when(couponApplyService).applyCoupon(any(), any());
+
+		//when //then
+		mockMvc.perform(
+				post("/api/coupons/apply")
+					.content(objectMapper.writeValueAsString(request))
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isCreated())
+			.andExpect(jsonPath("$.code").value("CREATED"))
+			.andExpect(jsonPath("$.message").value("CREATED"))
+			.andExpect(header().string("Location", "/api/users/1/coupons/1"))
+			.andDo(CouponDocumentation.applyCoupon());
+	}
+}

--- a/src/test/java/com/coffee_shop/coffeeshop/docs/coupon/CouponDocumentation.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/docs/coupon/CouponDocumentation.java
@@ -45,7 +45,31 @@ public class CouponDocumentation {
 					.description("응답 데이터")
 			),
 			responseHeaders(
-				headerWithName("Location").description("생성된 쿠폰 ID")
+				headerWithName("Location").description("생성된 쿠폰 URI")
+			)
+		);
+	}
+
+	public static RestDocumentationResultHandler applyCoupon() {
+		return document("coupon/apply",
+			preprocessRequest(prettyPrint()),
+			preprocessResponse(prettyPrint()),
+			requestFields(
+				fieldWithPath("userId").type(JsonFieldType.NUMBER).description("사용자 ID")
+					.attributes(key("constraints").value("양수")),
+				fieldWithPath("couponId").type(JsonFieldType.NUMBER).description("쿠폰 ID")
+					.attributes(key("constraints").value("양수"))
+			),
+			responseFields(
+				fieldWithPath("code").type(JsonFieldType.STRING)
+					.description("코드"),
+				fieldWithPath("message").type(JsonFieldType.STRING)
+					.description("메시지"),
+				fieldWithPath("data").type(JsonFieldType.NULL)
+					.description("응답 데이터")
+			),
+			responseHeaders(
+				headerWithName("Location").description("쿠폰 발급 결과 URI")
 			)
 		);
 	}

--- a/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/CouponTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/CouponTest.java
@@ -1,0 +1,71 @@
+package com.coffee_shop.coffeeshop.domain.coupon;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import com.coffee_shop.coffeeshop.domain.cash.Cash;
+
+class CouponTest {
+	@DisplayName("쿠폰 타입이 비율 할인인 경우 쿠폰 생성시 소수점으로 변환한다.")
+	@Test
+	void convertDiscountAmount() {
+		//when
+		Coupon coupon = Coupon.builder()
+			.name("오픈할인 쿠폰")
+			.type(CouponType.PERCENTAGE)
+			.discountAmount(10)
+			.minOrderAmount(1000)
+			.build();
+
+		//then
+		assertThat(coupon.getDiscountAmount()).isEqualTo(Cash.of("0.1"));
+	}
+
+	@DisplayName("발급된 쿠폰 개수가 최대 발급수보다 작을 경우 발급이 가능하다.")
+	@Test
+	void canIssueCoupon() {
+		//given
+		Coupon coupon = createCoupon(10, 9);
+
+		//when, then
+		assertTrue(coupon.canIssueCoupon());
+	}
+
+	@DisplayName("발급된 쿠폰 개수가 최대 발급수보다 클 경우 발급이 불가능하다.")
+	@Test
+	void soldOutCoupon() {
+		//given
+		Coupon coupon = createCoupon(10, 10);
+
+		//when, then
+		assertFalse(coupon.canIssueCoupon());
+	}
+
+	@DisplayName("쿠폰이 발급되면 발급 개수를 +1 한다.")
+	@Test
+	void issueCoupon() {
+		//given
+		Coupon coupon = createCoupon(10, 1);
+
+		//when
+		coupon.issueCoupon();
+
+		//then
+		assertThat(coupon.getIssuedCount()).isEqualTo(2);
+	}
+
+	private Coupon createCoupon(int maxIssueCount, int issuedCount) {
+		return Coupon.builder()
+			.name("오픈할인 쿠폰")
+			.type(CouponType.AMOUNT)
+			.discountAmount(100)
+			.minOrderAmount(1000)
+			.maxIssueCount(maxIssueCount)
+			.issuedCount(issuedCount)
+			.build();
+	}
+
+}

--- a/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumerTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumerTest.java
@@ -25,6 +25,7 @@ import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
 import com.coffee_shop.coffeeshop.service.coupon.CouponApplyService;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
 
 class CouponMessageQConsumerTest extends IntegrationTestSupport {
 	@Autowired
@@ -58,7 +59,7 @@ class CouponMessageQConsumerTest extends IntegrationTestSupport {
 		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
 
 		//when
-		couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+		couponApplyService.applyCoupon(createRequest(user.getId(), coupon.getId()), issueDateTime);
 
 		//then
 		Thread.sleep(1000);
@@ -94,7 +95,7 @@ class CouponMessageQConsumerTest extends IntegrationTestSupport {
 		for (int i = 0; i < maxIssueCount; i++) {
 			executorService.submit(() -> {
 				try {
-					couponApplyService.applyCoupon(users.remove(), coupon.getId(), issueDateTime);
+					couponApplyService.applyCoupon(createRequest(users.remove(), coupon.getId()), issueDateTime);
 				} finally {
 					latch.countDown();
 				}
@@ -112,6 +113,13 @@ class CouponMessageQConsumerTest extends IntegrationTestSupport {
 		assertThat(coupons.get(0).getIssuedCount()).isEqualTo(maxIssueCount);
 
 		assertTrue(messageQ.isEmpty());
+	}
+
+	private CouponApplyServiceRequest createRequest(Long userId, Long couponId) {
+		return CouponApplyServiceRequest.builder()
+			.userId(userId)
+			.couponId(couponId)
+			.build();
 	}
 
 	private Coupon createCoupon(int maxIssueCount, int issuedCount) {

--- a/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumerTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumerTest.java
@@ -22,11 +22,11 @@ import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistoryReposito
 import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
-import com.coffee_shop.coffeeshop.service.coupon.CouponIssueService;
+import com.coffee_shop.coffeeshop.service.coupon.CouponApplyService;
 
 class CouponMessageQConsumerTest extends IntegrationTestSupport {
 	@Autowired
-	private CouponIssueService couponIssueService;
+	private CouponApplyService couponApplyService;
 
 	@Autowired
 	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
@@ -53,7 +53,7 @@ class CouponMessageQConsumerTest extends IntegrationTestSupport {
 		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
 
 		//when
-		couponIssueService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+		couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
 
 		//then
 		Thread.sleep(1000);
@@ -82,7 +82,7 @@ class CouponMessageQConsumerTest extends IntegrationTestSupport {
 		for (int i = 0; i < maxIssueCount; i++) {
 			executorService.submit(() -> {
 				try {
-					couponIssueService.applyCoupon(users.remove(), coupon.getId(), issueDateTime);
+					couponApplyService.applyCoupon(users.remove(), coupon.getId(), issueDateTime);
 				} finally {
 					latch.countDown();
 				}

--- a/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumerTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumerTest.java
@@ -1,0 +1,118 @@
+package com.coffee_shop.coffeeshop.domain.coupon.consumer;
+
+import static com.coffee_shop.coffeeshop.domain.coupon.CouponType.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.domain.user.UserRepository;
+import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
+import com.coffee_shop.coffeeshop.service.coupon.CouponIssueService;
+
+class CouponMessageQConsumerTest extends IntegrationTestSupport {
+	@Autowired
+	private CouponIssueService couponIssueService;
+
+	@Autowired
+	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@AfterEach
+	void tearDown() {
+		couponTransactionHistoryRepository.deleteAllInBatch();
+		couponRepository.deleteAllInBatch();
+		userRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("한명의 고객에게 쿠폰을 발급한다.")
+	@Test
+	void issueCoupon() throws InterruptedException {
+		//given
+		Coupon coupon = couponRepository.save(createCoupon(10, 0));
+		User user = userRepository.save(createUser());
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+
+		//when
+		couponIssueService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+
+		//then
+		Thread.sleep(1000);
+		assertThat(couponTransactionHistoryRepository.findAll()).hasSize(1);
+	}
+
+	@DisplayName("쿠폰을 여러명에게 발급한다.")
+	@Test
+	public void issueCouponsToMultipleUsers() throws InterruptedException {
+		//given
+		int maxIssueCount = 1000;
+		Coupon coupon = couponRepository.save(createCoupon(maxIssueCount, 0));
+
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+
+		Queue<Long> users = new ConcurrentLinkedDeque<>();
+		for (int i = 0; i < maxIssueCount; i++) {
+			User user = userRepository.save(createUser());
+			users.add(user.getId());
+		}
+
+		//when
+		ExecutorService executorService = Executors.newFixedThreadPool(32);
+		CountDownLatch latch = new CountDownLatch(maxIssueCount);
+
+		for (int i = 0; i < maxIssueCount; i++) {
+			executorService.submit(() -> {
+				try {
+					couponIssueService.applyCoupon(users.remove(), coupon.getId(), issueDateTime);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+		//then
+		Thread.sleep(2000);
+
+		assertThat(couponTransactionHistoryRepository.findAll()).hasSize(maxIssueCount);
+		List<Coupon> coupons = couponRepository.findAll();
+		assertThat(coupons.get(0).getIssuedCount()).isEqualTo(maxIssueCount);
+	}
+
+	private Coupon createCoupon(int maxIssueCount, int issuedCount) {
+		return Coupon.builder()
+			.name("오픈기념 선착순 할인 쿠폰")
+			.type(AMOUNT)
+			.discountAmount(1000)
+			.minOrderAmount(4000)
+			.maxIssueCount(maxIssueCount)
+			.issuedCount(issuedCount)
+			.build();
+	}
+
+	private User createUser() {
+		return User.builder()
+			.name("우경서")
+			.build();
+	}
+}

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponApplyServiceTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponApplyServiceTest.java
@@ -27,7 +27,7 @@ import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
 
-class CouponIssueServiceTest extends IntegrationTestSupport {
+class CouponApplyServiceTest extends IntegrationTestSupport {
 
 	@Autowired
 	private UserRepository userRepository;
@@ -41,14 +41,14 @@ class CouponIssueServiceTest extends IntegrationTestSupport {
 	@MockBean
 	private CouponConsumer couponMessageQConsumer;
 
-	private CouponIssueService couponIssueService;
+	private CouponApplyService couponApplyService;
 	private MessageQ messageQ;
 
 	@BeforeEach
 	void setUp() {
 		messageQ = new MessageQ();
 		CouponMessageQProducer couponMessageQProducer = new CouponMessageQProducer(messageQ);
-		couponIssueService = new CouponIssueService(userRepository, couponRepository, couponMessageQProducer,
+		couponApplyService = new CouponApplyService(userRepository, couponRepository, couponMessageQProducer,
 			couponTransactionHistoryRepository);
 	}
 
@@ -68,7 +68,7 @@ class CouponIssueServiceTest extends IntegrationTestSupport {
 		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
 
 		//when
-		couponIssueService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+		couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
 
 		//then
 		assertThat(messageQ.size()).isEqualTo(1);
@@ -90,7 +90,7 @@ class CouponIssueServiceTest extends IntegrationTestSupport {
 		for (int i = 0; i < maxIssueCount; i++) {
 			executorService.submit(() -> {
 				try {
-					couponIssueService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+					couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
 				} finally {
 					latch.countDown();
 				}
@@ -114,7 +114,7 @@ class CouponIssueServiceTest extends IntegrationTestSupport {
 
 		//when, then
 		assertThatThrownBy(
-			() -> couponIssueService.applyCoupon(user.getId(), coupon.getId(), issueDateTime))
+			() -> couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("쿠폰이 모두 소진되어 발급할 수 없습니다.");
 	}
@@ -131,7 +131,7 @@ class CouponIssueServiceTest extends IntegrationTestSupport {
 
 		//when, then
 		assertThatThrownBy(
-			() -> couponIssueService.applyCoupon(user.getId(), coupon.getId(), issueDateTime))
+			() -> couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("이미 발급된 쿠폰입니다. 사용자 ID, 이름 : " + user.getId() + ", "
 				+ user.getName());

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponApplyServiceTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponApplyServiceTest.java
@@ -26,6 +26,7 @@ import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponMessageQProducer;
 import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
 
 class CouponApplyServiceTest extends IntegrationTestSupport {
 
@@ -68,7 +69,7 @@ class CouponApplyServiceTest extends IntegrationTestSupport {
 		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
 
 		//when
-		couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+		couponApplyService.applyCoupon(createRequest(user.getId(), coupon.getId()), issueDateTime);
 
 		//then
 		assertThat(messageQ.size()).isEqualTo(1);
@@ -90,7 +91,7 @@ class CouponApplyServiceTest extends IntegrationTestSupport {
 		for (int i = 0; i < maxIssueCount; i++) {
 			executorService.submit(() -> {
 				try {
-					couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+					couponApplyService.applyCoupon(createRequest(user.getId(), coupon.getId()), issueDateTime);
 				} finally {
 					latch.countDown();
 				}
@@ -114,7 +115,7 @@ class CouponApplyServiceTest extends IntegrationTestSupport {
 
 		//when, then
 		assertThatThrownBy(
-			() -> couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime))
+			() -> couponApplyService.applyCoupon(createRequest(user.getId(), coupon.getId()), issueDateTime))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("쿠폰이 모두 소진되어 발급할 수 없습니다.");
 	}
@@ -131,10 +132,17 @@ class CouponApplyServiceTest extends IntegrationTestSupport {
 
 		//when, then
 		assertThatThrownBy(
-			() -> couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime))
+			() -> couponApplyService.applyCoupon(createRequest(user.getId(), coupon.getId()), issueDateTime))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("이미 발급된 쿠폰입니다. 사용자 ID, 이름 : " + user.getId() + ", "
 				+ user.getName());
+	}
+
+	private CouponApplyServiceRequest createRequest(Long userId, Long couponId) {
+		return CouponApplyServiceRequest.builder()
+			.userId(userId)
+			.couponId(couponId)
+			.build();
 	}
 
 	private CouponTransactionHistory createCouponTransactionHistory(Coupon coupon, User user,

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueFailHandlerTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueFailHandlerTest.java
@@ -1,0 +1,262 @@
+package com.coffee_shop.coffeeshop.service.coupon;
+
+import static com.coffee_shop.coffeeshop.domain.coupon.CouponType.*;
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.domain.user.UserRepository;
+import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
+
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+
+class CouponIssueFailHandlerTest extends IntegrationTestSupport {
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@Autowired
+	private CouponIssueFailHandler couponIssueFailHandler;
+
+	@Autowired
+	private CouponApplyService couponApplyService;
+
+	@Autowired
+	private MessageQ messageQ;
+
+	@Autowired
+	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
+
+	@SpyBean
+	private CouponIssueService couponIssueService;
+
+	private Long exceptionUserId;
+
+	@AfterEach
+	void tearDown() {
+		couponTransactionHistoryRepository.deleteAllInBatch();
+		couponRepository.deleteAllInBatch();
+		userRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("한개 쿠폰 발급 실패 시 최대 실패 횟수가 초과하면 실패로그를 남기고 발급을 실패한다.")
+	@Test
+	void failIssueCoupon() throws InterruptedException {
+		//given
+		int maxFailCount = 3;
+		Coupon coupon = couponRepository.save(createCoupon(10, 0));
+		User user = userRepository.save(createUser());
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+
+		doThrow(new RuntimeException()).when(couponIssueService).issueCoupon(any(CouponApplication.class));
+
+		ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+		Logger logger = (Logger)LoggerFactory.getLogger(CouponIssueFailHandler.class);
+		logger.addAppender(listAppender);
+		listAppender.start();
+
+		//when
+		couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+
+		//then
+		Thread.sleep(1000);
+
+		assertThat(couponTransactionHistoryRepository.findAll()).hasSize(0);
+
+		int expectedIssuedCount = couponRepository.findById(coupon.getId()).get().getIssuedCount();
+		assertThat(expectedIssuedCount).isEqualTo(0);
+
+		assertTrue(messageQ.isEmpty());
+
+		List<ILoggingEvent> testLogs = listAppender.list;
+		assertThat(testLogs.size()).isEqualTo(7);
+		assertThat(testLogs.get(0).getMessage()).isEqualTo(
+			"최대 실패 횟수 " + maxFailCount + "회를 초과하였습니다. 실패 횟수 : " + maxFailCount);
+		assertThat(testLogs.get(2).getMessage()).isEqualTo(
+			"실패한 메시지 : CouponApplication{userId=" + user.getId() + ", couponId=" + coupon.getId() + ", issueDateTime="
+				+ issueDateTime + ", failCount=" + maxFailCount
+				+ ", exceptionList=[java.lang.RuntimeException, java.lang.RuntimeException, java.lang.RuntimeException]}");
+	}
+
+	@DisplayName("여러개의 쿠폰 발급 실패 시 한개의 쿠폰발급에서 예외가 발생하면 큐의 맨앞으로 넣어 재시도후 성공하면 정상 발급한다.")
+	@Test
+	void retryFailIssueCoupons() throws InterruptedException {
+		//given
+		int maxIssueCount = 1000;
+		int maxFailCount = 3;
+
+		Coupon coupon = couponRepository.save(createCoupon(maxIssueCount, 0));
+
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+
+		//log 체크
+		ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+		Logger logger = (Logger)LoggerFactory.getLogger(CouponIssueFailHandler.class);
+		logger.addAppender(listAppender);
+		listAppender.start();
+
+		//10명 유저 생성
+		Queue<Long> users = new ConcurrentLinkedDeque<>();
+		for (int i = 0; i < maxIssueCount; i++) {
+			User user = userRepository.save(createUser());
+			users.add(user.getId());
+			if (i == 0) {
+				exceptionUserId = user.getId();
+			}
+		}
+
+		for (int i = 0; i < maxFailCount - 1; i++) {
+			doThrow(new RuntimeException()).when(couponIssueService).issueCoupon(CouponApplication.builder()
+				.userId(exceptionUserId)
+				.couponId(coupon.getId())
+				.issueDateTime(issueDateTime)
+				.failCount(i)
+				.build());
+		}
+
+		//when
+		ExecutorService executorService = Executors.newFixedThreadPool(32);
+		CountDownLatch latch = new CountDownLatch(maxIssueCount);
+
+		for (int i = 0; i < maxIssueCount; i++) {
+			executorService.submit(() -> {
+				try {
+					couponApplyService.applyCoupon(users.remove(), coupon.getId(), issueDateTime);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+		//then
+		Thread.sleep(4000);
+
+		assertThat(couponTransactionHistoryRepository.findAll()).hasSize(maxIssueCount);
+
+		List<Coupon> coupons = couponRepository.findAll();
+		assertThat(coupons.get(0).getIssuedCount()).isEqualTo(maxIssueCount);
+
+		assertTrue(messageQ.isEmpty());
+
+		List<ILoggingEvent> testLogs = listAppender.list;
+		assertThat(testLogs.size()).isEqualTo(0);
+	}
+
+	@DisplayName("여러개의 쿠폰 발급 실패 시 한개의 쿠폰이 예외가 터져 최대 실패 회수를 초과하여 발급에 실패하면 해당 발급은 실패로그를 남기고 실패한다. 나머지는 정상 발급된다.")
+	@Test
+	void failIssueCoupons() throws InterruptedException {
+		//given
+		int maxIssueCount = 1000;
+		int maxFailCount = 3;
+
+		Coupon coupon = couponRepository.save(createCoupon(maxIssueCount, 0));
+
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+
+		//log 체크
+		ListAppender<ILoggingEvent> listAppender = new ListAppender<>();
+		Logger logger = (Logger)LoggerFactory.getLogger(CouponIssueFailHandler.class);
+		logger.addAppender(listAppender);
+		listAppender.start();
+
+		//1000명 유저 생성
+		Queue<Long> users = new ConcurrentLinkedDeque<>();
+		for (int i = 0; i < maxIssueCount; i++) {
+			User user = userRepository.save(createUser());
+			users.add(user.getId());
+			if (i == 2) {
+				exceptionUserId = user.getId();
+			}
+		}
+
+		for (int i = 0; i < maxFailCount; i++) {
+			doThrow(new RuntimeException()).when(couponIssueService).issueCoupon(CouponApplication.builder()
+				.userId(exceptionUserId)
+				.couponId(coupon.getId())
+				.issueDateTime(issueDateTime)
+				.failCount(i)
+				.build());
+		}
+
+		//when
+		ExecutorService executorService = Executors.newFixedThreadPool(32);
+		CountDownLatch latch = new CountDownLatch(maxIssueCount);
+
+		for (int i = 0; i < maxIssueCount; i++) {
+			executorService.submit(() -> {
+				try {
+					couponApplyService.applyCoupon(users.remove(), coupon.getId(), issueDateTime);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+		//then
+		Thread.sleep(4000);
+
+		assertThat(couponTransactionHistoryRepository.findAll()).hasSize(maxIssueCount - 1);
+
+		List<Coupon> coupons = couponRepository.findAll();
+		assertThat(coupons.get(0).getIssuedCount()).isEqualTo(maxIssueCount - 1);
+
+		assertTrue(messageQ.isEmpty());
+
+		List<ILoggingEvent> testLogs = listAppender.list;
+		assertThat(testLogs.size()).isEqualTo(7);
+		assertThat(testLogs.get(0).getMessage()).isEqualTo(
+			"최대 실패 횟수 " + maxFailCount + "회를 초과하였습니다. 실패 횟수 : " + maxFailCount);
+		assertThat(testLogs.get(2).getMessage()).isEqualTo(
+			"실패한 메시지 : CouponApplication{userId=" + exceptionUserId + ", couponId=" + coupon.getId()
+				+ ", issueDateTime="
+				+ issueDateTime + ", failCount=" + maxFailCount
+				+ ", exceptionList=[java.lang.RuntimeException, java.lang.RuntimeException, java.lang.RuntimeException]}");
+	}
+
+	private Coupon createCoupon(int maxIssueCount, int issuedCount) {
+		return Coupon.builder()
+			.name("오픈기념 선착순 할인 쿠폰")
+			.type(AMOUNT)
+			.discountAmount(1000)
+			.minOrderAmount(4000)
+			.maxIssueCount(maxIssueCount)
+			.issuedCount(issuedCount)
+			.build();
+	}
+
+	private User createUser() {
+		return User.builder()
+			.name("우경서")
+			.build();
+	}
+
+}

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueFailHandlerTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueFailHandlerTest.java
@@ -28,6 +28,7 @@ import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
 
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
@@ -81,7 +82,7 @@ class CouponIssueFailHandlerTest extends IntegrationTestSupport {
 		listAppender.start();
 
 		//when
-		couponApplyService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+		couponApplyService.applyCoupon(createRequest(user.getId(), coupon.getId()), issueDateTime);
 
 		//then
 		Thread.sleep(1000);
@@ -146,7 +147,7 @@ class CouponIssueFailHandlerTest extends IntegrationTestSupport {
 		for (int i = 0; i < maxIssueCount; i++) {
 			executorService.submit(() -> {
 				try {
-					couponApplyService.applyCoupon(users.remove(), coupon.getId(), issueDateTime);
+					couponApplyService.applyCoupon(createRequest(users.remove(), coupon.getId()), issueDateTime);
 				} finally {
 					latch.countDown();
 				}
@@ -212,7 +213,7 @@ class CouponIssueFailHandlerTest extends IntegrationTestSupport {
 		for (int i = 0; i < maxIssueCount; i++) {
 			executorService.submit(() -> {
 				try {
-					couponApplyService.applyCoupon(users.remove(), coupon.getId(), issueDateTime);
+					couponApplyService.applyCoupon(createRequest(users.remove(), coupon.getId()), issueDateTime);
 				} finally {
 					latch.countDown();
 				}
@@ -240,6 +241,13 @@ class CouponIssueFailHandlerTest extends IntegrationTestSupport {
 				+ ", issueDateTime="
 				+ issueDateTime + ", failCount=" + maxFailCount
 				+ ", exceptionList=[java.lang.RuntimeException, java.lang.RuntimeException, java.lang.RuntimeException]}");
+	}
+
+	private CouponApplyServiceRequest createRequest(Long userId, Long couponId) {
+		return CouponApplyServiceRequest.builder()
+			.userId(userId)
+			.couponId(couponId)
+			.build();
 	}
 
 	private Coupon createCoupon(int maxIssueCount, int issuedCount) {

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueServiceTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueServiceTest.java
@@ -1,0 +1,165 @@
+package com.coffee_shop.coffeeshop.service.coupon;
+
+import static com.coffee_shop.coffeeshop.domain.coupon.CouponType.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.mock.mockito.MockBean;
+
+import com.coffee_shop.coffeeshop.common.exception.BusinessException;
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
+import com.coffee_shop.coffeeshop.domain.coupon.consumer.CouponConsumer;
+import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponMessageQProducer;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.domain.user.UserRepository;
+import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
+
+class CouponIssueServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@Autowired
+	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
+
+	@MockBean
+	private CouponConsumer couponMessageQConsumer;
+
+	private CouponIssueService couponIssueService;
+	private MessageQ messageQ;
+
+	@BeforeEach
+	void setUp() {
+		messageQ = new MessageQ();
+		CouponMessageQProducer couponMessageQProducer = new CouponMessageQProducer(messageQ);
+		couponIssueService = new CouponIssueService(userRepository, couponRepository, couponMessageQProducer,
+			couponTransactionHistoryRepository);
+	}
+
+	@AfterEach
+	void tearDown() {
+		couponTransactionHistoryRepository.deleteAllInBatch();
+		couponRepository.deleteAllInBatch();
+		userRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("고객이 쿠폰 발급 신청할경우 메시지 큐에 쌓인다.")
+	@Test
+	void applyCoupon() {
+		//given
+		Coupon coupon = couponRepository.save(createCoupon(10, 0));
+		User user = userRepository.save(createUser());
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+
+		//when
+		couponIssueService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+
+		//then
+		assertThat(messageQ.size()).isEqualTo(1);
+	}
+
+	@DisplayName("쿠폰을 여러명이 발급 신청할경우 메시지 큐에 신청 개수만큼 쌓인다.")
+	@Test
+	void applyCoupons() throws InterruptedException {
+		//given
+		int maxIssueCount = 1000;
+		Coupon coupon = couponRepository.save(createCoupon(maxIssueCount, 0));
+		User user = userRepository.save(createUser());
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+
+		//when
+		ExecutorService executorService = Executors.newFixedThreadPool(32);
+		CountDownLatch latch = new CountDownLatch(maxIssueCount);
+
+		for (int i = 0; i < maxIssueCount; i++) {
+			executorService.submit(() -> {
+				try {
+					couponIssueService.applyCoupon(user.getId(), coupon.getId(), issueDateTime);
+				} finally {
+					latch.countDown();
+				}
+			});
+		}
+
+		latch.await();
+
+		//then
+		assertThat(messageQ.size()).isEqualTo(maxIssueCount);
+	}
+
+	@DisplayName("선착순 쿠폰 수량이 소진된 경우 쿠폰 발급 신청시 발급이 불가능하다.")
+	@Test
+	public void applyCouponWhenCouponLimitReached() {
+		//given
+		Coupon coupon = couponRepository.save(createCoupon(10, 10));
+		User user = userRepository.save(createUser());
+
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+
+		//when, then
+		assertThatThrownBy(
+			() -> couponIssueService.applyCoupon(user.getId(), coupon.getId(), issueDateTime))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("쿠폰이 모두 소진되어 발급할 수 없습니다.");
+	}
+
+	@DisplayName("한명의 사용자에게 동일한 쿠폰을 중복으로 발급할 수 없다.")
+	@Test
+	public void applyCouponToUniqueUser() {
+		//given
+		Coupon coupon = couponRepository.save(createCoupon(10, 0));
+		User user = userRepository.save(createUser());
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+
+		couponTransactionHistoryRepository.save(createCouponTransactionHistory(coupon, user, issueDateTime));
+
+		//when, then
+		assertThatThrownBy(
+			() -> couponIssueService.applyCoupon(user.getId(), coupon.getId(), issueDateTime))
+			.isInstanceOf(BusinessException.class)
+			.hasMessage("이미 발급된 쿠폰입니다. 사용자 ID, 이름 : " + user.getId() + ", "
+				+ user.getName());
+	}
+
+	private CouponTransactionHistory createCouponTransactionHistory(Coupon coupon, User user,
+		LocalDateTime issueDateTime) {
+		return CouponTransactionHistory.builder()
+			.user(user)
+			.coupon(coupon)
+			.issueDateTime(issueDateTime)
+			.build();
+	}
+
+	private Coupon createCoupon(int maxIssueCount, int issuedCount) {
+		return Coupon.builder()
+			.name("오픈기념 선착순 할인 쿠폰")
+			.type(AMOUNT)
+			.discountAmount(1000)
+			.minOrderAmount(4000)
+			.maxIssueCount(maxIssueCount)
+			.issuedCount(issuedCount)
+			.build();
+	}
+
+	private User createUser() {
+		return User.builder()
+			.name("우경서")
+			.build();
+	}
+}

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponServiceTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/CouponServiceTest.java
@@ -49,8 +49,8 @@ class CouponServiceTest extends IntegrationTestSupport {
 
 		List<Coupon> coupons = couponRepository.findAll();
 		assertThat(coupons).hasSize(1)
-			.extracting("id", "type", "discountAmount", "minOrderAmount", "maxIssueCount")
-			.containsExactlyInAnyOrder(tuple(couponId, AMOUNT, Cash.of(1000), 4000, 1000));
+			.extracting("id", "type", "discountAmount", "minOrderAmount", "maxIssueCount", "issuedCount")
+			.containsExactlyInAnyOrder(tuple(couponId, AMOUNT, Cash.of(1000), 4000, 1000, 0));
 	}
 
 	@DisplayName("비율 할인 쿠폰을 생성한다.")
@@ -73,7 +73,7 @@ class CouponServiceTest extends IntegrationTestSupport {
 
 		List<Coupon> coupons = couponRepository.findAll();
 		assertThat(coupons).hasSize(1)
-			.extracting("id", "type", "discountAmount", "minOrderAmount", "maxIssueCount")
-			.containsExactlyInAnyOrder(tuple(couponId, PERCENTAGE, Cash.of("0.5"), 4000, 1000));
+			.extracting("id", "type", "discountAmount", "minOrderAmount", "maxIssueCount", "issuedCount")
+			.containsExactlyInAnyOrder(tuple(couponId, PERCENTAGE, Cash.of("0.5"), 4000, 1000, 0));
 	}
 }

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,3 +1,5 @@
 spring.profiles.active=test
 logging.level.org.springframework.jdbc=debug
 logging.level.org.hibernate.SQL=DEBUG
+logging.level.org.springframework.transaction.interceptor=TRACE
+logging.level.org.springframework.jdbc.datasource.DataSourceTransactionManager=DEBUG


### PR DESCRIPTION
## 선착순 쿠폰 발급 기능 - 내부 큐
1. coupon 발급 신청 (CouponProducer가 queue add message)
   - 큐는 ConcurrentLinkedQueue를 사용했습니다.
2. CouponConsumer가 1초마다 queue 확인하여 message 꺼내서 발급 처리
   - 동시성 이슈는 Synchronized 블럭을 사용했습니다.
3. 쿠폰 발급 중 실패시 다시 큐에 넣어 발급 재시도를 하고 최대 발급 횟수를 초과했을 경우 재시도를 중지하고 log를 남긴 후 종료합니다.
4. 발급 결과는 발급신청 api 응답 header에 GET::/users/{user}/coupons/{coupon} 으로 발급 신청 결과 확인하도록 유도할 것이며 해당 api는 추후 이슈 생성하여 구현 예정입니다.