### PR TITLE
[#23] Redis 쿠폰 발급 처리량을 외부에서 조절가능하도록 수정

### DIFF
--- a/src/main/java/com/coffee_shop/coffeeshop/common/config/RedisConfig.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/common/config/RedisConfig.java
@@ -41,4 +41,13 @@ public class RedisConfig {
 		redisTemplate.setValueSerializer(new GenericJackson2JsonRedisSerializer());
 		return redisTemplate;
 	}
+
+	@Bean
+	public RedisTemplate<String, String> redisTemplateString() {
+		RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
+		redisTemplate.setConnectionFactory(redisConnectionFactory());
+		redisTemplate.setKeySerializer(new StringRedisSerializer());
+		redisTemplate.setValueSerializer(new StringRedisSerializer());
+		return redisTemplate;
+	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/common/config/RedisConfig.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/common/config/RedisConfig.java
@@ -34,7 +34,7 @@ public class RedisConfig {
 	}
 
 	@Bean
-	public RedisTemplate<String, Object> objectRedisTemplate() {
+	public RedisTemplate<String, Object> redisTemplateJson() {
 		RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
 		redisTemplate.setConnectionFactory(redisConnectionFactory());
 		redisTemplate.setKeySerializer(new StringRedisSerializer());

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/RedisCouponConsumer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/RedisCouponConsumer.java
@@ -8,6 +8,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssuanceRateRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueRepository;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
 import com.coffee_shop.coffeeshop.service.coupon.issue.RedisCouponIssueService;
@@ -20,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Component
 public class RedisCouponConsumer implements CouponConsumer {
-	private static final long RANGE_COUNT = 10L;
+	private final CouponIssuanceRateRepository couponIssuanceRateRepository;
 	private final CouponIssueRepository couponIssueRepository;
 	private final RedisCouponIssueFailHandler redisCouponIssueFailHandler;
 	private final RedisCouponIssueService redisCouponIssueService;
@@ -32,7 +33,8 @@ public class RedisCouponConsumer implements CouponConsumer {
 			return;
 		}
 
-		Set<ZSetOperations.TypedTuple<Object>> popped = couponIssueRepository.popMin(RANGE_COUNT);
+		long rangeCount = couponIssuanceRateRepository.getRangeCount();
+		Set<ZSetOperations.TypedTuple<Object>> popped = couponIssueRepository.popMin(rangeCount);
 		for (ZSetOperations.TypedTuple<Object> typedTuple : popped) {
 			Object object = typedTuple.getValue();
 			if (!(object instanceof CouponApplication)) {

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssuanceRateRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssuanceRateRepository.java
@@ -1,0 +1,43 @@
+package com.coffee_shop.coffeeshop.domain.coupon.repository;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class CouponIssuanceRateRepository {
+	private static final long MAX_RANGE_COUNT = 50L;
+	private static final long DEFAULT_RANGE_COUNT = 10L;
+	private static final String COUPON_ISSUANCE_RATE_KEY_PREFIX = "coupon_issuance_rate";
+
+	private final RedisTemplate<String, String> redisTemplateString;
+
+	public long getRangeCount() {
+		long rangeCount = DEFAULT_RANGE_COUNT;
+		String issuanceRate = null;
+
+		try {
+			issuanceRate = getIssuanceRate();
+			rangeCount = Long.parseLong(issuanceRate);
+			if (rangeCount > MAX_RANGE_COUNT) {
+				rangeCount = MAX_RANGE_COUNT;
+				log.warn(
+					"Coupon issuance rate exceeded. Current rate: {}, Max rate: {}. Action required to adjust configuration or throttle requests.",
+					rangeCount, MAX_RANGE_COUNT);
+			}
+		} catch (NumberFormatException e) {
+			log.warn(
+				"Invalid number format for conversion to long. Provided input: '{}'.", issuanceRate);
+		}
+
+		return rangeCount;
+	}
+
+	private String getIssuanceRate() {
+		return redisTemplateString.opsForValue().get(COUPON_ISSUANCE_RATE_KEY_PREFIX);
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueRepository.java
@@ -14,16 +14,16 @@ import lombok.RequiredArgsConstructor;
 @Repository
 public class CouponIssueRepository {
 	private static final String COUPON_QUEUE_KEY_PREFIX = "coupon_issue_queue";
-	private final RedisTemplate<String, Object> redisTemplate;
+	private final RedisTemplate<String, Object> redisTemplateJson;
 
 	public void add(CouponApplication application, long timestamp) {
-		redisTemplate
+		redisTemplateJson
 			.opsForZSet()
 			.add(COUPON_QUEUE_KEY_PREFIX, application, timestamp);
 	}
 
 	public Long count() {
-		return redisTemplate
+		return redisTemplateJson
 			.opsForZSet()
 			.zCard(COUPON_QUEUE_KEY_PREFIX);
 	}
@@ -33,7 +33,7 @@ public class CouponIssueRepository {
 	}
 
 	public Set<ZSetOperations.TypedTuple<Object>> popMin(long count) {
-		return redisTemplate
+		return redisTemplateJson
 			.opsForZSet()
 			.popMin(COUPON_QUEUE_KEY_PREFIX, count);
 	}

--- a/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssuanceRateRepositoryTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssuanceRateRepositoryTest.java
@@ -1,0 +1,83 @@
+package com.coffee_shop.coffeeshop.domain.coupon.repository;
+
+import java.util.Set;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
+
+class CouponIssuanceRateRepositoryTest extends IntegrationTestSupport {
+	private static final String COUPON_ISSUANCE_RATE_KEY_PREFIX = "coupon_issuance_rate";
+
+	@Autowired
+	private CouponIssuanceRateRepository couponIssuanceRateRepository;
+
+	@Autowired
+	private RedisTemplate<String, String> redisTemplateString;
+
+	@AfterEach
+	void tearDown() {
+		clearAll();
+	}
+
+	@DisplayName("redis에서 쿠폰 처리량 설정 값을 가져온다.")
+	@Test
+	void getIssuanceRate() {
+		//given
+		redisTemplateString.opsForValue().set(COUPON_ISSUANCE_RATE_KEY_PREFIX, "20");
+
+		//when
+		long rangeCount = couponIssuanceRateRepository.getRangeCount();
+
+		//then
+		Assertions.assertThat(rangeCount).isEqualTo(20L);
+	}
+
+	@DisplayName("redis에서 쿠폰 처리량 설정 값을 가져올 때 해당 키가 없으면 기본값인 10을 반환한다.")
+	@Test
+	void getDefaultIssuanceRateWhenRedisDoesNotExistKey() {
+		//when
+		long rangeCount = couponIssuanceRateRepository.getRangeCount();
+
+		//then
+		Assertions.assertThat(rangeCount).isEqualTo(10L);
+	}
+
+	@DisplayName("쿠폰 처리량 설정 값을 숫자로 변환할 수 없는 값을 넣었을때 기본값인 10을 반환한다.")
+	@Test
+	void getDefaultIssuanceRateWhenValueCanNotConvertToNumber() {
+		//given
+		redisTemplateString.opsForValue().set(COUPON_ISSUANCE_RATE_KEY_PREFIX, "test");
+
+		//when
+		long rangeCount = couponIssuanceRateRepository.getRangeCount();
+
+		//then
+		Assertions.assertThat(rangeCount).isEqualTo(10L);
+	}
+
+	@DisplayName("쿠폰 처리량 설정 값을 최대 처리량보다 큰 값을 넣었을때 최대값인 50을 반환한다.")
+	@Test
+	void getMaxIssuanceRateWhenValueExceededMaxValue() {
+		//given
+		redisTemplateString.opsForValue().set(COUPON_ISSUANCE_RATE_KEY_PREFIX, "55");
+
+		//when
+		long rangeCount = couponIssuanceRateRepository.getRangeCount();
+
+		//then
+		Assertions.assertThat(rangeCount).isEqualTo(50L);
+	}
+
+	private void clearAll() {
+		Set<String> keys = redisTemplateString.keys("*");
+		if (keys != null && !keys.isEmpty()) {
+			redisTemplateString.delete(keys);
+		}
+	}
+}

--- a/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueRepositoryTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueRepositoryTest.java
@@ -30,7 +30,7 @@ class CouponIssueRepositoryTest extends IntegrationTestSupport {
 	private CouponIssueRepository couponIssueRepository;
 
 	@Autowired
-	private RedisTemplate<String, Object> redisTemplate;
+	private RedisTemplate<String, Object> redisTemplateJson;
 
 	@AfterEach
 	void tearDown() {
@@ -102,9 +102,9 @@ class CouponIssueRepositoryTest extends IntegrationTestSupport {
 	}
 
 	private void clearAll() {
-		Set<String> keys = redisTemplate.keys("*");
+		Set<String> keys = redisTemplateJson.keys("*");
 		if (keys != null && !keys.isEmpty()) {
-			redisTemplate.delete(keys);
+			redisTemplateJson.delete(keys);
 		}
 	}
 


### PR DESCRIPTION
## Redis 쿠폰 발급 처리량을 외부에서 조절가능하도록 수정

### 기능 설명
- 기존 방식은 소스 상에서 상수 10으로 처리량을 고정해 쿠폰 발급 처리를 했습니다. 이 값을 외부에서 관리하도록 변경하여 런타임 환경에서 조절 가능하도록 했습니다.

### 구현 이유
- 트래픽이 몰려 처리량을 실시간으로 늘리고 싶을 때 소스를 수정해 재배포해야 한다는 점이 운영환경에서 빠른 대응이 어려워 유연한 조치를 위해 필요했습니다.  

### 구현 과정
- 쿠폰 발급 처리량을 redis string으로 설정해 놓고 발급 스케줄이 동작할 때마다 해당 값을 조회하도록 했습니다. 설정 값이 없을 경우 10으로 처리량을 많이 설정했을 경우 최대 처리량을 50으로 제한했습니다.
- spring cloud config & spring cloud bus를 고려해 봤었는데 일단 추가 서버가 필요하고 러닝 커브가 있어, 외부에서 관리할 설정값이 쿠폰 발급 처리량 1개뿐인 현재 제 상황에서는 간단하게 redis를 사용하는 편이 합리적이라 생각했습니다.
- 매번 redis에서 발급량을 조회한다는 점이 redis에 부하가 갈 가능성이 있어 추후 추가적인 이슈를 생성해서 spring cache를 활용해 설정값을 캐싱 하여 보완할 예정입니다.