### PR TITLE
[#24] 쿠폰 발급 개수 DB 동기화 기능 추가

### DIFF
--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/Coupon.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/Coupon.java
@@ -90,4 +90,8 @@ public class Coupon extends BaseTimeEntity {
 	public void issueCoupon() {
 		issuedCount += 1;
 	}
+
+	public void updateIssuedCount(Long issuedCount) {
+		this.issuedCount = issuedCount.intValue();
+	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueCountRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueCountRepository.java
@@ -4,7 +4,9 @@ import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @RequiredArgsConstructor
 @Repository
 public class CouponIssueCountRepository {
@@ -15,6 +17,20 @@ public class CouponIssueCountRepository {
 		return redisTemplate
 			.opsForValue()
 			.increment(getKey(couponId));
+	}
+
+	public Long getIssueCount(Long couponId) {
+		Long issueCount = redisTemplate
+			.opsForValue()
+			.get(getKey(couponId));
+
+		if (issueCount == null) {
+			log.warn("Redis key '{}' does not exist or used in transaction/pipeline",
+				COUPON_COUNT_KEY_PREFIX + couponId);
+			return 0L;
+		}
+
+		return issueCount;
 	}
 
 	private String getKey(Long couponId) {

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponService.java
@@ -1,14 +1,19 @@
 package com.coffee_shop.coffeeshop.service.coupon;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
+import com.coffee_shop.coffeeshop.common.exception.BusinessException;
 import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
+import com.coffee_shop.coffeeshop.exception.ErrorCode;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponSaveServiceRequest;
 
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
+@Slf4j
 @Transactional(readOnly = true)
 @RequiredArgsConstructor
 @Service
@@ -19,5 +24,17 @@ public class CouponService {
 	public Long createCoupon(CouponSaveServiceRequest request) {
 		Coupon savedCoupon = couponRepository.save(Coupon.of(request));
 		return savedCoupon.getId();
+	}
+
+	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	public void syncCouponIssuedCount(Long couponId, Long increment) {
+		Coupon coupon = findCoupon(couponId);
+		coupon.updateIssuedCount(increment);
+	}
+
+	private Coupon findCoupon(Long couponId) {
+		return couponRepository.findById(couponId)
+			.orElseThrow(
+				() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND, "Coupon Not Found, 쿠폰 ID : " + couponId));
 	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/RedisCouponApplyService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/RedisCouponApplyService.java
@@ -63,14 +63,14 @@ public class RedisCouponApplyService implements CouponApplyService {
 
 		checkDuplicateIssuedCoupon(user);
 
-		Long couponCount = couponIssueCountRepository.increment(coupon.getId());
-		isCouponLimitExceeded(coupon, couponCount);
+		Long issueCount = couponIssueCountRepository.getIssueCount(coupon.getId());
+		isCouponLimitExceeded(coupon, issueCount);
 
 		redisCouponProducer.applyCoupon(user, coupon);
 	}
 
-	private void isCouponLimitExceeded(Coupon coupon, Long couponCount) {
-		if (couponCount > coupon.getMaxIssueCount()) {
+	private void isCouponLimitExceeded(Coupon coupon, Long issueCount) {
+		if (issueCount + 1 > coupon.getMaxIssueCount()) {
 			throw new BusinessException(ErrorCode.COUPON_LIMIT_REACHED);
 		}
 	}

--- a/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueCountRepositoryTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueCountRepositoryTest.java
@@ -1,0 +1,76 @@
+package com.coffee_shop.coffeeshop.domain.coupon.repository;
+
+import static com.coffee_shop.coffeeshop.domain.coupon.CouponType.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.util.Set;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
+
+class CouponIssueCountRepositoryTest extends IntegrationTestSupport {
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@Autowired
+	private CouponIssueCountRepository couponIssueCountRepository;
+
+	@Autowired
+	private RedisTemplate<String, Long> redisTemplate;
+
+	@AfterEach
+	void tearDown() {
+		clearAll();
+	}
+
+	@DisplayName("쿠폰 발급 수를 증가시킨다.")
+	@Test
+	void increment() {
+		//given
+		Coupon coupon = createCoupon();
+
+		//when
+		Long increment = couponIssueCountRepository.increment(coupon.getId());
+
+		//then
+		assertThat(increment).isEqualTo(1L);
+	}
+
+	@DisplayName("쿠폰 발급 수를 조회할 때 키가 없을 경우 0을 반환한다.")
+	@Test
+	void getIssueCountWhenKeyDoesNotExist() {
+		//given
+		Coupon coupon = createCoupon();
+
+		//when
+		Long increment = couponIssueCountRepository.getIssueCount(coupon.getId());
+
+		//then
+		assertThat(increment).isEqualTo(0L);
+	}
+
+	private Coupon createCoupon() {
+		Coupon coupon = Coupon.builder()
+			.name("오픈기념 선착순 할인 쿠폰")
+			.type(AMOUNT)
+			.discountAmount(1000)
+			.minOrderAmount(4000)
+			.maxIssueCount(10)
+			.issuedCount(0)
+			.build();
+		return couponRepository.save(coupon);
+	}
+
+	private void clearAll() {
+		Set<String> keys = redisTemplate.keys("*");
+		if (keys != null && !keys.isEmpty()) {
+			redisTemplate.delete(keys);
+		}
+	}
+}


### PR DESCRIPTION
## 쿠폰 발급 개수 10개 단위로 DB 동기화 기능 구현
### 기능 설명
- 현재 쿠폰 발급 개수를 redis string으로 관리하고 있습니다. redis로 관리하게 되면 성능에 이점이 있지만 에러가 발생했을 때 해당 값을 쉽게 잃을 가능성이 있습니다. 따라서 DB에 주기적으로 동기화할 필요가 있어 10개 단위로 쿠폰 발급 개수를 동기화 하도록 구현했습니다.

### 구현 이유
- 위 방식으로 구현한 이유는 매 발급 시마다 DB로 동기화를 하게 되면 redis를 사용하는 이점이 없어 주기를 조절할 필요가 있었습니다.
- 또한 해당 값을 잃게 되더라도 10개 이내로 오차가 발생하기 때문에 오차 범위가 작아 큰 손실이 발생하지 않습니다.

### 구현 과정
- 동기화 로직을 트랜잭션 전파 레벨을 Propagation.REQUIRES_NEW로 설정해서 쿠폰 발급과 트랜잭션을 분리해 동기화 과정이 쿠폰 발급에 영향이 없도록 했습니다.
- 이벤트 발행 방식 + 비동기로 트랜잭션을 분리해서 처리하는 방식도 고려하였으나 비동기로 구현하게 되면 순차적으로 DB에 반영된다는 보장이 없기 때문에 매 동기화마다 redis에서 쿠폰 발급 개수를 가져와야 하는 점이 있어 동기방식이 적합한 것 같아 위 방식을 택했습니다.