### PR TITLE
[#21] Redis로 선착순 쿠폰 발급 기능 전환 - 대기 순번 조회 

### DIFF
--- a/src/main/java/com/coffee_shop/coffeeshop/common/domain/RedisIncrRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/common/domain/RedisIncrRepository.java
@@ -1,0 +1,34 @@
+package com.coffee_shop.coffeeshop.common.domain;
+
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Repository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class RedisIncrRepository {
+	private final RedisTemplate<String, Long> redisTemplate;
+
+	public Long increment(String key) {
+		return redisTemplate
+			.opsForValue()
+			.increment(key);
+	}
+
+	public Long getIssueCount(String key) {
+		Long issueCount = redisTemplate
+			.opsForValue()
+			.get(key);
+
+		if (issueCount == null) {
+			log.warn("Redis key '{}' does not exist or used in transaction/pipeline",
+				key);
+			return 0L;
+		}
+
+		return issueCount;
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/common/domain/RedisRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/common/domain/RedisRepository.java
@@ -9,7 +9,7 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 @Repository
-public class RedisIncrRepository {
+public class RedisRepository {
 	private final RedisTemplate<String, Long> redisTemplate;
 
 	public Long increment(String key) {

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponMessageQProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponMessageQProducer.java
@@ -4,9 +4,11 @@ import java.util.ArrayList;
 
 import org.springframework.stereotype.Component;
 
+import com.coffee_shop.coffeeshop.common.exception.BusinessException;
 import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
 import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
 import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.exception.ErrorCode;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
 
 import lombok.RequiredArgsConstructor;
@@ -16,8 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Component
 public class CouponMessageQProducer implements CouponProducer {
-	private static final int POSITION_NOT_FOUND = -1;
-
 	private final MessageQ messageQ;
 
 	@Override
@@ -44,12 +44,7 @@ public class CouponMessageQProducer implements CouponProducer {
 			}
 		}
 
-		return POSITION_NOT_FOUND;
-	}
-
-	@Override
-	public boolean isPositionNotFound(int position) {
-		return position == POSITION_NOT_FOUND;
+		throw new BusinessException(ErrorCode.POSITION_NOT_FOUND);
 	}
 
 	private boolean isMatchingApplication(Long userId, Long couponId, CouponApplication application) {

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponMessageQProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponMessageQProducer.java
@@ -33,13 +33,13 @@ public class CouponMessageQProducer implements CouponProducer {
 	}
 
 	@Override
-	public int getPosition(Long userId, Long couponId) {
+	public int getPosition(User user, Coupon coupon) {
 		ArrayList<CouponApplication> couponApplications = messageQ.toArrayList();
 		int qSize = couponApplications.size();
 
 		for (int i = 0; i < qSize; i++) {
 			CouponApplication application = couponApplications.get(i);
-			if (isMatchingApplication(userId, couponId, application)) {
+			if (isMatchingApplication(user.getId(), coupon.getId(), application)) {
 				return i + 1;
 			}
 		}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponProducer.java
@@ -6,7 +6,7 @@ import com.coffee_shop.coffeeshop.domain.user.User;
 public interface CouponProducer {
 	void applyCoupon(User user, Coupon coupon);
 
-	int getPosition(Long userId, Long couponId);
+	int getPosition(User user, Coupon coupon);
 
 	boolean isPositionNotFound(int position);
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponProducer.java
@@ -7,6 +7,4 @@ public interface CouponProducer {
 	void applyCoupon(User user, Coupon coupon);
 
 	int getPosition(User user, Coupon coupon);
-
-	boolean isPositionNotFound(int position);
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/RedisCouponProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/RedisCouponProducer.java
@@ -26,7 +26,7 @@ public class RedisCouponProducer implements CouponProducer {
 	}
 
 	@Override
-	public int getPosition(Long userId, Long couponId) {
+	public int getPosition(User user, Coupon coupon) {
 		return POSITION_NOT_FOUND;
 	}
 

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/RedisCouponProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/RedisCouponProducer.java
@@ -3,9 +3,11 @@ package com.coffee_shop.coffeeshop.domain.coupon.producer;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
+import com.coffee_shop.coffeeshop.common.exception.BusinessException;
 import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueRepository;
 import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.exception.ErrorCode;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
 
 import lombok.RequiredArgsConstructor;
@@ -27,7 +29,12 @@ public class RedisCouponProducer implements CouponProducer {
 
 	@Override
 	public int getPosition(User user, Coupon coupon) {
-		return POSITION_NOT_FOUND;
+		Long position = couponIssueRepository.findPosition(CouponApplication.of(user, coupon));
+		if (position == null) {
+			throw new BusinessException(ErrorCode.POSITION_NOT_FOUND);
+		}
+
+		return position.intValue() + 1;
 	}
 
 	@Override

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/RedisCouponProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/RedisCouponProducer.java
@@ -22,7 +22,7 @@ public class RedisCouponProducer implements CouponProducer {
 
 	@Override
 	public void applyCoupon(User user, Coupon coupon) {
-		long timestamp = System.currentTimeMillis() / 1000;
+		long timestamp = System.currentTimeMillis();
 		couponIssueRepository.add(CouponApplication.of(user, coupon), timestamp);
 	}
 

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/RedisCouponProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/RedisCouponProducer.java
@@ -18,7 +18,6 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Component
 public class RedisCouponProducer implements CouponProducer {
-	private static final int POSITION_NOT_FOUND = -1;
 	private final CouponIssueRepository couponIssueRepository;
 
 	@Override
@@ -35,10 +34,5 @@ public class RedisCouponProducer implements CouponProducer {
 		}
 
 		return position.intValue() + 1;
-	}
-
-	@Override
-	public boolean isPositionNotFound(int position) {
-		return position == POSITION_NOT_FOUND;
 	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponFailCountRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponFailCountRepository.java
@@ -2,7 +2,7 @@ package com.coffee_shop.coffeeshop.domain.coupon.repository;
 
 import org.springframework.stereotype.Repository;
 
-import com.coffee_shop.coffeeshop.common.domain.RedisIncrRepository;
+import com.coffee_shop.coffeeshop.common.domain.RedisRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,14 +12,14 @@ import lombok.extern.slf4j.Slf4j;
 @Repository
 public class CouponFailCountRepository {
 	private static final String COUPON_FAIL_COUNT_KEY_PREFIX = "coupon_fail_count:";
-	private final RedisIncrRepository redisIncrRepository;
+	private final RedisRepository redisRepository;
 
 	public Long increment(Long userId) {
-		return redisIncrRepository.increment(getKey(userId));
+		return redisRepository.increment(getKey(userId));
 	}
 
 	public Long getIssueCount(Long userId) {
-		return redisIncrRepository.getIssueCount(getKey(userId));
+		return redisRepository.getIssueCount(getKey(userId));
 	}
 
 	private String getKey(Long userId) {

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponFailCountRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponFailCountRepository.java
@@ -1,0 +1,28 @@
+package com.coffee_shop.coffeeshop.domain.coupon.repository;
+
+import org.springframework.stereotype.Repository;
+
+import com.coffee_shop.coffeeshop.common.domain.RedisIncrRepository;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Repository
+public class CouponFailCountRepository {
+	private static final String COUPON_FAIL_COUNT_KEY_PREFIX = "coupon_fail_count:";
+	private final RedisIncrRepository redisIncrRepository;
+
+	public Long increment(Long userId) {
+		return redisIncrRepository.increment(getKey(userId));
+	}
+
+	public Long getIssueCount(Long userId) {
+		return redisIncrRepository.getIssueCount(getKey(userId));
+	}
+
+	private String getKey(Long userId) {
+		return COUPON_FAIL_COUNT_KEY_PREFIX + userId;
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueCountRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueCountRepository.java
@@ -2,7 +2,7 @@ package com.coffee_shop.coffeeshop.domain.coupon.repository;
 
 import org.springframework.stereotype.Repository;
 
-import com.coffee_shop.coffeeshop.common.domain.RedisIncrRepository;
+import com.coffee_shop.coffeeshop.common.domain.RedisRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -12,14 +12,14 @@ import lombok.extern.slf4j.Slf4j;
 @Repository
 public class CouponIssueCountRepository {
 	private static final String COUPON_COUNT_KEY_PREFIX = "coupon_issue_count:";
-	private final RedisIncrRepository redisIncrRepository;
+	private final RedisRepository redisRepository;
 
 	public Long increment(Long couponId) {
-		return redisIncrRepository.increment(getKey(couponId));
+		return redisRepository.increment(getKey(couponId));
 	}
 
 	public Long getIssueCount(Long couponId) {
-		return redisIncrRepository.getIssueCount(getKey(couponId));
+		return redisRepository.getIssueCount(getKey(couponId));
 	}
 
 	private String getKey(Long couponId) {

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueCountRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueCountRepository.java
@@ -1,7 +1,8 @@
 package com.coffee_shop.coffeeshop.domain.coupon.repository;
 
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Repository;
+
+import com.coffee_shop.coffeeshop.common.domain.RedisIncrRepository;
 
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -11,26 +12,14 @@ import lombok.extern.slf4j.Slf4j;
 @Repository
 public class CouponIssueCountRepository {
 	private static final String COUPON_COUNT_KEY_PREFIX = "coupon_issue_count:";
-	private final RedisTemplate<String, Long> redisTemplate;
+	private final RedisIncrRepository redisIncrRepository;
 
 	public Long increment(Long couponId) {
-		return redisTemplate
-			.opsForValue()
-			.increment(getKey(couponId));
+		return redisIncrRepository.increment(getKey(couponId));
 	}
 
 	public Long getIssueCount(Long couponId) {
-		Long issueCount = redisTemplate
-			.opsForValue()
-			.get(getKey(couponId));
-
-		if (issueCount == null) {
-			log.warn("Redis key '{}' does not exist or used in transaction/pipeline",
-				COUPON_COUNT_KEY_PREFIX + couponId);
-			return 0L;
-		}
-
-		return issueCount;
+		return redisIncrRepository.getIssueCount(getKey(couponId));
 	}
 
 	private String getKey(Long couponId) {

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueRepository.java
@@ -32,6 +32,10 @@ public class CouponIssueRepository {
 		return count() == 0L;
 	}
 
+	public Long findPosition(CouponApplication application) {
+		return redisTemplateJson.opsForZSet().rank(COUPON_QUEUE_KEY_PREFIX, application);
+	}
+
 	public Set<ZSetOperations.TypedTuple<Object>> popMin(long count) {
 		return redisTemplateJson
 			.opsForZSet()

--- a/src/main/java/com/coffee_shop/coffeeshop/exception/ErrorCode.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/exception/ErrorCode.java
@@ -21,7 +21,8 @@ public enum ErrorCode {
 	INVALID_DISCOUNT_PERCENTAGE(HttpStatus.BAD_REQUEST, "INVALID_DISCOUNT_PERCENTAGE", "할인율은 1~100까지 입력가능합니다."),
 	COUPON_LIMIT_REACHED(HttpStatus.BAD_REQUEST, "COUPON_LIMIT_REACHED", "쿠폰이 모두 소진되어 발급할 수 없습니다."),
 	COUPON_DUPLICATE_ISSUE(HttpStatus.BAD_REQUEST, "COUPON_DUPLICATE_ISSUE", "이미 발급된 쿠폰입니다."),
-	OVER_MAX_ORDER_COUNT(HttpStatus.BAD_REQUEST, "OVER_MAX_ORDER_COUNT", "최대 주문 가능 수량은 20개 입니다.");
+	OVER_MAX_ORDER_COUNT(HttpStatus.BAD_REQUEST, "OVER_MAX_ORDER_COUNT", "최대 주문 가능 수량은 20개 입니다."),
+	POSITION_NOT_FOUND(HttpStatus.NOT_FOUND, "POSITION_NOT_FOUND", "대기 순번을 찾을 수 없습니다.");
 
 	private final HttpStatus httpStatus;
 	private final String code;

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyServiceImpl.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyServiceImpl.java
@@ -40,13 +40,12 @@ public class CouponApplyServiceImpl implements CouponApplyService {
 			return CouponApplyResponse.of(CouponIssueStatus.SUCCESS);
 		}
 
-		int position = couponMessageQProducer.getPosition(user, coupon);
-		if (couponMessageQProducer.isPositionNotFound(position)) {
+		try {
+			int position = couponMessageQProducer.getPosition(user, coupon);
+			return CouponApplyResponse.of(CouponIssueStatus.IN_PROGRESS, position);
+		} catch (BusinessException e) {
 			return CouponApplyResponse.of(CouponIssueStatus.FAILURE);
 		}
-
-		return CouponApplyResponse.of(CouponIssueStatus.IN_PROGRESS, position);
-
 	}
 
 	@Transactional

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyServiceImpl.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyServiceImpl.java
@@ -40,7 +40,7 @@ public class CouponApplyServiceImpl implements CouponApplyService {
 			return CouponApplyResponse.of(CouponIssueStatus.SUCCESS);
 		}
 
-		int position = couponMessageQProducer.getPosition(userId, couponId);
+		int position = couponMessageQProducer.getPosition(user, coupon);
 		if (couponMessageQProducer.isPositionNotFound(position)) {
 			return CouponApplyResponse.of(CouponIssueStatus.FAILURE);
 		}

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/RedisCouponApplyService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/RedisCouponApplyService.java
@@ -47,7 +47,7 @@ public class RedisCouponApplyService implements CouponApplyService {
 			return CouponApplyResponse.of(CouponIssueStatus.SUCCESS);
 		}
 
-		int position = redisCouponProducer.getPosition(userId, couponId);
+		int position = redisCouponProducer.getPosition(user, coupon);
 		if (redisCouponProducer.isPositionNotFound(position)) {
 			return CouponApplyResponse.of(CouponIssueStatus.FAILURE);
 		}

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/RedisCouponApplyService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/RedisCouponApplyService.java
@@ -36,7 +36,6 @@ public class RedisCouponApplyService implements CouponApplyService {
 	private final AppliedUserRepository appliedUserRepository;
 
 	public CouponApplyResponse isCouponIssued(Long userId, Long couponId) {
-		//todo : 변환해야함
 		User user = findUser(userId);
 		Coupon coupon = findCoupon(couponId);
 
@@ -47,13 +46,12 @@ public class RedisCouponApplyService implements CouponApplyService {
 			return CouponApplyResponse.of(CouponIssueStatus.SUCCESS);
 		}
 
-		int position = redisCouponProducer.getPosition(user, coupon);
-		if (redisCouponProducer.isPositionNotFound(position)) {
+		try {
+			int position = redisCouponProducer.getPosition(user, coupon);
+			return CouponApplyResponse.of(CouponIssueStatus.IN_PROGRESS, position);
+		} catch (BusinessException e) {
 			return CouponApplyResponse.of(CouponIssueStatus.FAILURE);
 		}
-
-		return CouponApplyResponse.of(CouponIssueStatus.IN_PROGRESS, position);
-
 	}
 
 	@Transactional

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/RedisCouponIssueFailHandler.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/RedisCouponIssueFailHandler.java
@@ -1,11 +1,10 @@
 package com.coffee_shop.coffeeshop.service.coupon.issue.fail;
 
-import java.util.List;
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponFailCountRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueRepository;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
 
@@ -17,28 +16,19 @@ public class RedisCouponIssueFailHandler implements CouponIssueFailHandler {
 	private static final Logger log = LoggerFactory.getLogger(RedisCouponIssueFailHandler.class);
 	private static final int MAX_FAIL_COUNT = 3;
 	private final CouponIssueRepository couponIssueRepository;
+	private final CouponFailCountRepository couponFailCountRepository;
 
 	public void handleFail(CouponApplication couponApplication, Exception exception) {
-		couponApplication.addException(exception);
-		couponApplication.increaseFailCount();
+		Long failCount = couponFailCountRepository.increment(couponApplication.getUserId());
 
-		if (couponApplication.getFailCount() >= MAX_FAIL_COUNT) {
-			handleTooManyFails(couponApplication);
+		if (failCount >= MAX_FAIL_COUNT) {
+			log.warn("최대 실패 횟수 {}회를 초과하였습니다. 실패 횟수 : {}", MAX_FAIL_COUNT, failCount);
 		} else {
+			log.warn("쿠폰 발급 실패 재시도 회수 : {}, 사용자 ID : {}, 쿠폰 ID : {}", failCount, couponApplication.getUserId(),
+				couponApplication.getCouponId());
 			couponIssueRepository.add(couponApplication, System.currentTimeMillis());
 		}
-	}
 
-	private void handleTooManyFails(CouponApplication couponApplication) {
-		log.info("최대 실패 횟수 {}회를 초과하였습니다. 실패 횟수 : {}", MAX_FAIL_COUNT, couponApplication.getFailCount());
-		log.info("---------------------- 예외 리스트 START ----------------------");
-		List<Exception> exceptionList = couponApplication.getExceptionList();
-		log.info("실패한 메시지 : {}", couponApplication);
-		for (int i = 0; i < couponApplication.getExceptionList().size(); i++) {
-			Exception e = exceptionList.get(i);
-			e.printStackTrace();
-			log.info("----------------------------------");
-		}
-		log.info("---------------------- 예외 리스트 END ----------------------");
+		log.warn("쿠폰 발급 중 예외 발생", exception);
 	}
 }

--- a/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueRepositoryTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueRepositoryTest.java
@@ -6,7 +6,6 @@ import static org.junit.jupiter.api.Assertions.*;
 
 import java.util.Set;
 
-import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -44,12 +43,10 @@ class CouponIssueRepositoryTest extends IntegrationTestSupport {
 
 		CouponApplication couponApplication1 = CouponApplication.of(user, coupon);
 		CouponApplication couponApplication2 = CouponApplication.of(user, coupon, 0);
-		CouponApplication couponApplication3 = CouponApplication.of(user, coupon, 1);
 		couponIssueRepository.add(couponApplication1, 1731488205);
 		couponIssueRepository.add(couponApplication2, 1731488206);
-		couponIssueRepository.add(couponApplication3, 1731488206);
 
-		Assertions.assertThat(couponIssueRepository.count()).isEqualTo(2L);
+		assertThat(couponIssueRepository.count()).isEqualTo(1L);
 	}
 
 	@Test
@@ -61,12 +58,12 @@ class CouponIssueRepositoryTest extends IntegrationTestSupport {
 		couponIssueRepository.add(CouponApplication.of(user1, coupon), 1731488205);
 		couponIssueRepository.add(CouponApplication.of(user2, coupon), 1731488206);
 
-		Assertions.assertThat(couponIssueRepository.count()).isEqualTo(2L);
+		assertThat(couponIssueRepository.count()).isEqualTo(2L);
 	}
 
 	@Test
 	void countWhenKeyDoesNotExist() {
-		Assertions.assertThat(couponIssueRepository.count()).isEqualTo(0L);
+		assertThat(couponIssueRepository.count()).isEqualTo(0L);
 	}
 
 	@Test
@@ -99,6 +96,42 @@ class CouponIssueRepositoryTest extends IntegrationTestSupport {
 				CouponApplication.of(user1, coupon, 0),
 				CouponApplication.of(user2, coupon, 0)
 			);
+	}
+
+	@Test
+	void findPosition() {
+		Coupon coupon = createCoupon();
+		User user1 = createUser();
+		User user2 = createUser();
+
+		CouponApplication couponApplication1 = CouponApplication.of(user1, coupon);
+		CouponApplication couponApplication2 = CouponApplication.of(user2, coupon);
+		couponIssueRepository.add(couponApplication1, 1731488205);
+		couponIssueRepository.add(couponApplication2, 1731488206);
+
+		assertThat(couponIssueRepository.findPosition(couponApplication1)).isEqualTo(0L);
+		assertThat(couponIssueRepository.findPosition(couponApplication2)).isEqualTo(1L);
+	}
+
+	@Test
+	void findPositionWhenQueueDoesNotExist() {
+		Coupon coupon = createCoupon();
+		User user = createUser();
+		CouponApplication couponApplication = CouponApplication.of(user, coupon);
+
+		assertThat(couponIssueRepository.findPosition(couponApplication)).isEqualTo(null);
+	}
+
+	@Test
+	void findPositionWhenValueDoesNotExist() {
+		Coupon coupon = createCoupon();
+		User user1 = createUser();
+		User user2 = createUser();
+		CouponApplication couponApplication = CouponApplication.of(user1, coupon);
+		CouponApplication couponApplication2 = CouponApplication.of(user2, coupon);
+		couponIssueRepository.add(couponApplication, 1731488206);
+
+		assertThat(couponIssueRepository.findPosition(couponApplication2)).isEqualTo(null);
 	}
 
 	private void clearAll() {

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyServiceImplTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyServiceImplTest.java
@@ -22,7 +22,7 @@ import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
 import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueStatus;
 import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
 import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
-import com.coffee_shop.coffeeshop.domain.coupon.consumer.CouponConsumer;
+import com.coffee_shop.coffeeshop.domain.coupon.consumer.CouponMessageQConsumer;
 import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponMessageQProducer;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHistoryRepository;
@@ -44,7 +44,7 @@ class CouponApplyServiceImplTest extends IntegrationTestSupport {
 	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
 
 	@MockBean
-	private CouponConsumer couponMessageQConsumer;
+	private CouponMessageQConsumer couponMessageQConsumer;
 
 	private CouponApplyService couponApplyService;
 	private MessageQ messageQ;
@@ -151,7 +151,7 @@ class CouponApplyServiceImplTest extends IntegrationTestSupport {
 
 	@DisplayName("쿠폰 발급이 완료된다면 발급 결과 조회시 발급 결과는 성공, 대기 순번은 -1로 반환된다.")
 	@Test
-	void IssueCouponSuccessfully() {
+	void findPositionWhenIssueCouponSuccessfully() {
 		//given
 		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
 		Coupon coupon = createCoupon(10, 0);
@@ -169,7 +169,7 @@ class CouponApplyServiceImplTest extends IntegrationTestSupport {
 
 	@DisplayName("쿠폰 발급 실패한다면 발급 결과 조회시 발급 결과는 실패, 대기 순번은 -1로 반환된다.")
 	@Test
-	void failToIssueCoupon() {
+	void findPositionWhenFailToIssueCoupon() {
 		//given
 		Coupon coupon = createCoupon(10, 0);
 		User user = createUser();
@@ -184,7 +184,7 @@ class CouponApplyServiceImplTest extends IntegrationTestSupport {
 
 	@DisplayName("쿠폰 발급중이라면 발급 결과 조회시 발급 결과는 발급중, 현재 대기열 순번이 반환된다.")
 	@Test
-	void inProgressWhenCouponIsBeingIssued() throws InterruptedException {
+	void findPositionWhenCouponIsBeingIssued() throws InterruptedException {
 		//given
 		int maxIssueCount = 10;
 		Coupon coupon = createCoupon(10, 0);


### PR DESCRIPTION
## Redis로 선착순 쿠폰 발급 기능 전환 - 대기 순번 조회
### 기능 설명
- 대기열 순번조회 기능을 sorted set 의 zrank 명령어를 사용해서 api를 구현하였습니다.

### 구현 과정
- sorted set에 들어가는 value값이 CouponApplication 객체를 직렬화해서 들어가게 되는데 이때 zrank 명령어로 조회를 하려면 CouponApplication 객체 내부 필드인 failCount(재시도 횟수)까지 포함해서 조회해야하는 고민사항이 있었습니다.
- 서버가 분리된 상황에서 실패 후 같은 서버에서 다시 재발급을 시도 한다는 보장이 없기 때문에 failCount를 외부에서 관리하도록 변경했고 redis string 으로 관리하도록 변경하였습니다. 내부 로직 상 쿠폰 발급이 실패해서 재시도를 하는 경우는 발급 시 서버 내부에 어떠한 문제가 발생해 실패가 되는 상황이라 사실상 휘발되어도 큰 무리가 없는 데이터이고 빠른 접근이 보장되어 redis를 사용했습니다. 