### PR TITLE
[#30] Lock wait timeout 문제 해결

### DIFF
--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/RedisCouponConsumer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/RedisCouponConsumer.java
@@ -12,7 +12,7 @@ import com.coffee_shop.coffeeshop.common.exception.BusinessException;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssuanceRateRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueRepository;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
-import com.coffee_shop.coffeeshop.service.coupon.issue.RedisCouponIssueService;
+import com.coffee_shop.coffeeshop.service.coupon.issue.RedisCouponIssueFacadeService;
 import com.coffee_shop.coffeeshop.service.coupon.issue.fail.RedisCouponIssueFailHandler;
 
 import lombok.RequiredArgsConstructor;
@@ -26,7 +26,7 @@ public class RedisCouponConsumer {
 	private final CouponIssuanceRateRepository couponIssuanceRateRepository;
 	private final CouponIssueRepository couponIssueRepository;
 	private final RedisCouponIssueFailHandler redisCouponIssueFailHandler;
-	private final RedisCouponIssueService redisCouponIssueService;
+	private final RedisCouponIssueFacadeService redisCouponIssueFacadeService;
 
 	@Scheduled(fixedRate = 1000)
 	public void issueCoupon() {
@@ -50,7 +50,7 @@ public class RedisCouponConsumer {
 
 	private void issueCoupon(CouponApplication couponApplication) {
 		try {
-			redisCouponIssueService.issueCoupon(couponApplication);
+			redisCouponIssueFacadeService.issueCoupon(couponApplication);
 		} catch (BusinessException e) {
 			log.info("쿠폰발급 실패 > {}", e.getMessage());
 		} catch (Exception e) {

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponService.java
@@ -1,7 +1,6 @@
 package com.coffee_shop.coffeeshop.service.coupon;
 
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
@@ -18,6 +17,7 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Service
 public class CouponService {
+	private static final int SYNC_COUNT = 10;
 	private final CouponRepository couponRepository;
 
 	@Transactional
@@ -26,9 +26,14 @@ public class CouponService {
 		return savedCoupon.getId();
 	}
 
-	@Transactional(propagation = Propagation.REQUIRES_NEW)
+	@Transactional
 	public void syncCouponIssuedCount(Long couponId, Long increment) {
 		Coupon coupon = findCoupon(couponId);
+
+		if (!isDbSyncRequired(increment, coupon)) {
+			return;
+		}
+		
 		coupon.updateIssuedCount(increment);
 	}
 
@@ -36,5 +41,14 @@ public class CouponService {
 		return couponRepository.findById(couponId)
 			.orElseThrow(
 				() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND, "Coupon Not Found, 쿠폰 ID : " + couponId));
+	}
+
+	private static boolean isDbSyncRequired(Long increment, Coupon coupon) {
+		if (increment == null || increment <= 0L) {
+			log.warn("Coupon could not be updated because issuedCount is null or zero");
+			return false;
+		}
+
+		return increment % SYNC_COUNT == 0 || increment == coupon.getMaxIssueCount();
 	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/RedisCouponIssueFacadeService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/RedisCouponIssueFacadeService.java
@@ -1,0 +1,36 @@
+package com.coffee_shop.coffeeshop.service.coupon.issue;
+
+import org.springframework.stereotype.Service;
+
+import com.coffee_shop.coffeeshop.common.exception.BusinessException;
+import com.coffee_shop.coffeeshop.service.coupon.CouponService;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class RedisCouponIssueFacadeService {
+	private final RedisCouponIssueService redisCouponIssueService;
+	private final CouponService couponService;
+
+	public void issueCoupon(CouponApplication couponApplication) {
+		Long couponId = couponApplication.getCouponId();
+
+		Long increment = redisCouponIssueService.issueCoupon(couponApplication);
+		try {
+			couponService.syncCouponIssuedCount(couponId, increment);
+		} catch (BusinessException e) {
+			log.warn(
+				"Business logic failed during coupon issuance count sync for couponId {}. The Redis increment value was {}. Details: {}",
+				couponId, increment, e.getMessage());
+		} catch (Exception e) {
+			log.warn(
+				"Unexpected error occurred while synchronizing coupon issuance count to the database for couponId {}. "
+					+ "The Redis increment value was {}. Details: {}",
+				couponId, increment, e.getMessage(), e);
+		}
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/RedisCouponIssueService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/RedisCouponIssueService.java
@@ -14,7 +14,6 @@ import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHist
 import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.exception.ErrorCode;
-import com.coffee_shop.coffeeshop.service.coupon.CouponService;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
 
 import lombok.RequiredArgsConstructor;
@@ -24,15 +23,13 @@ import lombok.extern.slf4j.Slf4j;
 @RequiredArgsConstructor
 @Component
 public class RedisCouponIssueService {
-	private static final int SYNC_COUNT = 10;
-	private final CouponService couponService;
 	private final UserRepository userRepository;
 	private final CouponRepository couponRepository;
 	private final CouponTransactionHistoryRepository couponTransactionHistoryRepository;
 	private final CouponIssueCountRepository couponIssueCountRepository;
 
 	@Transactional
-	public void issueCoupon(CouponApplication couponApplication) {
+	public Long issueCoupon(CouponApplication couponApplication) {
 		Coupon coupon = findCoupon(couponApplication.getCouponId());
 		User user = findUser(couponApplication.getUserId());
 
@@ -42,16 +39,7 @@ public class RedisCouponIssueService {
 		couponTransactionHistoryRepository.save(
 			CouponTransactionHistory.issueCoupon(user, coupon, LocalDateTime.now()));
 
-		Long increment = couponIssueCountRepository.increment(coupon.getId());
-		if (isDbSyncRequired(increment, coupon)) {
-			try {
-				couponService.syncCouponIssuedCount(coupon.getId(), increment);
-			} catch (BusinessException e) {
-				log.warn("Failed to synchronize coupon issuance count with the database. {}", e.getMessage());
-			} catch (Exception e) {
-				log.error("Failed to synchronize coupon issuance count with the database.", e);
-			}
-		}
+		return couponIssueCountRepository.increment(coupon.getId());
 	}
 
 	private Coupon findCoupon(Long couponId) {
@@ -69,14 +57,5 @@ public class RedisCouponIssueService {
 		if (issueCount + 1 > coupon.getMaxIssueCount()) {
 			throw new BusinessException(ErrorCode.COUPON_LIMIT_REACHED);
 		}
-	}
-
-	private static boolean isDbSyncRequired(Long increment, Coupon coupon) {
-		if (increment == null || increment <= 0L) {
-			log.warn("Coupon could not be updated because issuedCount is null or zero");
-			return false;
-		}
-
-		return increment % SYNC_COUNT == 0 || increment == coupon.getMaxIssueCount();
 	}
 }


### PR DESCRIPTION
### 문제
쿠폰 발급수 동기화가 실패와 동시에 Lock wait timeout exceeded; try restarting transaction 에러가 발생

### 원인 분석
_RedisCouponIssueService > issueCoupon_

```java
@Transactional
public void issueCoupon(CouponApplication couponApplication) {
        Coupon coupon = findCoupon(couponApplication.getCouponId()); // 락 획득
        
..생략

        if (isDbSyncRequired(increment, coupon)) {
	    try {
                 //  @Transactional(propagation = Propagation.REQUIRES_NEW)으로 동작 Lock wait timeout 발생
		couponService.syncCouponIssuedCount(coupon.getId(), increment);
	    }
..생략
        }
}


```

- 외부 트랜잭션에서 coupon을 조회하며 공유락이 걸린 상태로 내부에서 새로 트랜잭션을 시작하였습니다.
- 외부 트랜잭션은 커밋되지 않아 락이 반납되지 않은 채로 지속되어 내부 트랜잭션에서 Lock wait timeout이 발생하였습니다.

### 해결
- 파사드 패턴을 활용해서 트랜잭션을 짧게 가져가고 동기화 로직에서 Propagation.REQUIRES_NEW -> PROPAGATION_REQUIRED로 전파레벨을 변경하였습니다.