### PR TITLE
[#34] 쿠폰 발급 실패 이력 저장 로직 추가

### DIFF
--- a/src/main/java/com/coffee_shop/coffeeshop/controller/coupon/CouponApplyController.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/controller/coupon/CouponApplyController.java
@@ -13,6 +13,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 import com.coffee_shop.coffeeshop.common.dto.response.ApiResponse;
 import com.coffee_shop.coffeeshop.controller.coupon.dto.request.CouponApplyRequest;
+import com.coffee_shop.coffeeshop.service.coupon.CouponIssueStatusService;
 import com.coffee_shop.coffeeshop.service.coupon.apply.CouponApplyService;
 import com.coffee_shop.coffeeshop.service.coupon.dto.response.CouponApplyResponse;
 
@@ -22,6 +23,7 @@ import lombok.RequiredArgsConstructor;
 @RestController
 public class CouponApplyController {
 	private final CouponApplyService couponApplyService;
+	private final CouponIssueStatusService couponIssueStatusService;
 
 	@PostMapping("/api/coupons/apply")
 	public ResponseEntity<ApiResponse<Void>> applyCoupon(@RequestBody @Valid CouponApplyRequest request) {
@@ -33,7 +35,7 @@ public class CouponApplyController {
 
 	@GetMapping("/api/users/{userId}/coupons/{couponId}")
 	public ApiResponse<CouponApplyResponse> isCouponIssued(@PathVariable Long userId, @PathVariable Long couponId) {
-		CouponApplyResponse response = couponApplyService.isCouponIssued(userId, couponId);
+		CouponApplyResponse response = couponIssueStatusService.isCouponIssued(userId, couponId);
 		return ApiResponse.ok(response);
 	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/CouponIssueFailHistory.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/CouponIssueFailHistory.java
@@ -1,0 +1,58 @@
+package com.coffee_shop.coffeeshop.domain.coupon;
+
+import static jakarta.persistence.FetchType.*;
+
+import java.time.LocalDateTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+
+import com.coffee_shop.coffeeshop.common.domain.BaseTimeEntity;
+import com.coffee_shop.coffeeshop.domain.user.User;
+
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Entity
+@Table(name = "coupon_issue_fail_histories")
+public class CouponIssueFailHistory extends BaseTimeEntity {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	private Long id;
+
+	@ManyToOne(fetch = LAZY, optional = false)
+	@JoinColumn(name = "user_id")
+	private User user;
+
+	@ManyToOne(fetch = LAZY, optional = false)
+	@JoinColumn(name = "coupon_id")
+	private Coupon coupon;
+
+	@Column(nullable = false)
+	private LocalDateTime issueFailDateTime;
+
+	@Builder
+	private CouponIssueFailHistory(User user, Coupon coupon, LocalDateTime issueFailDateTime) {
+		this.user = user;
+		this.coupon = coupon;
+		this.issueFailDateTime = issueFailDateTime;
+	}
+
+	public static CouponIssueFailHistory of(User user, Coupon coupon, LocalDateTime issueFailDateTime) {
+		return CouponIssueFailHistory.builder()
+			.user(user)
+			.coupon(coupon)
+			.issueFailDateTime(issueFailDateTime)
+			.build();
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/CouponMessageQConsumer.java
@@ -29,10 +29,20 @@ public class CouponMessageQConsumer {
 			try {
 				couponIssueService.issueCoupon(couponApplication);
 			} catch (BusinessException e) {
-				log.info("쿠폰발급 실패 > {}", e.getMessage());
+				log.warn("쿠폰 발급 실패 > {}", e.getMessage());
 			} catch (Exception e) {
-				couponIssueFailHandler.handleFail(couponApplication, e);
+				handleFail(e, couponApplication);
 			}
+		}
+	}
+
+	private void handleFail(Exception exception, CouponApplication couponApplication) {
+		try {
+			couponIssueFailHandler.handleFail(couponApplication, exception);
+		} catch (BusinessException e) {
+			log.warn("쿠폰 발급 재시도 실패 > {}", e.getMessage());
+		} catch (Exception e) {
+			log.warn("쿠폰 발급 재시도 실패", e);
 		}
 	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/RedisCouponConsumer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/consumer/RedisCouponConsumer.java
@@ -52,9 +52,19 @@ public class RedisCouponConsumer {
 		try {
 			redisCouponIssueFacadeService.issueCoupon(couponApplication);
 		} catch (BusinessException e) {
-			log.info("쿠폰발급 실패 > {}", e.getMessage());
+			log.warn("쿠폰발급 실패 > {}", e.getMessage());
 		} catch (Exception e) {
-			redisCouponIssueFailHandler.handleFail(couponApplication, e);
+			handleFail(e, couponApplication);
+		}
+	}
+
+	private void handleFail(Exception exception, CouponApplication couponApplication) {
+		try {
+			redisCouponIssueFailHandler.handleFail(couponApplication, exception);
+		} catch (BusinessException e) {
+			log.warn("쿠폰 발급 재시도 실패 > {}", e.getMessage());
+		} catch (Exception e) {
+			log.warn("쿠폰 발급 재시도 실패", e);
 		}
 	}
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponMessageQProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponMessageQProducer.java
@@ -2,6 +2,7 @@ package com.coffee_shop.coffeeshop.domain.coupon.producer;
 
 import java.util.ArrayList;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
@@ -17,7 +18,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class CouponMessageQProducer {
+@ConditionalOnProperty(name = "schedule.active", havingValue = "messageQ")
+public class CouponMessageQProducer implements CouponProducer {
 	private final MessageQ messageQ;
 
 	public void applyCoupon(User user, Coupon coupon) {

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/CouponProducer.java
@@ -1,0 +1,10 @@
+package com.coffee_shop.coffeeshop.domain.coupon.producer;
+
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.user.User;
+
+public interface CouponProducer {
+	void applyCoupon(User user, Coupon coupon);
+
+	int getPosition(User user, Coupon coupon);
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/RedisCouponProducer.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/producer/RedisCouponProducer.java
@@ -1,5 +1,6 @@
 package com.coffee_shop.coffeeshop.domain.coupon.producer;
 
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
@@ -15,7 +16,8 @@ import lombok.extern.slf4j.Slf4j;
 @Slf4j
 @RequiredArgsConstructor
 @Component
-public class RedisCouponProducer {
+@ConditionalOnProperty(name = "schedule.active", havingValue = "redis")
+public class RedisCouponProducer implements CouponProducer {
 	private final CouponIssueRepository couponIssueRepository;
 
 	public void applyCoupon(User user, Coupon coupon) {

--- a/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueFailHistoryRepository.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/domain/coupon/repository/CouponIssueFailHistoryRepository.java
@@ -1,0 +1,13 @@
+package com.coffee_shop.coffeeshop.domain.coupon.repository;
+
+import java.util.Optional;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueFailHistory;
+import com.coffee_shop.coffeeshop.domain.user.User;
+
+public interface CouponIssueFailHistoryRepository extends JpaRepository<CouponIssueFailHistory, Long> {
+	Optional<CouponIssueFailHistory> findByCouponAndUser(Coupon coupon, User user);
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueStatusService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/CouponIssueStatusService.java
@@ -1,0 +1,77 @@
+package com.coffee_shop.coffeeshop.service.coupon;
+
+import java.util.Optional;
+
+import org.springframework.stereotype.Service;
+
+import com.coffee_shop.coffeeshop.common.exception.BusinessException;
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueFailHistory;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueStatus;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
+import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponProducer;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueFailHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.domain.user.UserRepository;
+import com.coffee_shop.coffeeshop.exception.ErrorCode;
+import com.coffee_shop.coffeeshop.service.coupon.dto.response.CouponApplyResponse;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class CouponIssueStatusService {
+	private final UserRepository userRepository;
+	private final CouponRepository couponRepository;
+	private final CouponProducer couponProducer;
+	private final CouponTransactionHistoryRepository couponTransactionHistoryRepository;
+	private final CouponIssueFailHistoryRepository couponIssueFailHistoryRepository;
+
+	public CouponApplyResponse isCouponIssued(Long userId, Long couponId) {
+		User user = findUser(userId);
+		Coupon coupon = findCoupon(couponId);
+
+		Optional<CouponTransactionHistory> transactionHistory = findCouponTransactionHistory(coupon, user);
+		if (transactionHistory.isPresent()) {
+			return CouponApplyResponse.of(CouponIssueStatus.SUCCESS);
+		}
+
+		Optional<CouponIssueFailHistory> failHistory = findCouponIssueFailHistory(coupon, user);
+		if (failHistory.isPresent()) {
+			return CouponApplyResponse.of(CouponIssueStatus.FAILURE);
+		}
+
+		int position = 0;
+		try {
+			position = couponProducer.getPosition(user, coupon);
+		} catch (BusinessException e) {
+			log.warn("Position not found for userId: {}, couponId: {} in the coupon application queue.", user.getId(),
+				coupon.getId());
+		}
+
+		return CouponApplyResponse.of(CouponIssueStatus.IN_PROGRESS, position);
+	}
+
+	private Optional<CouponIssueFailHistory> findCouponIssueFailHistory(Coupon coupon, User user) {
+		return couponIssueFailHistoryRepository.findByCouponAndUser(coupon,
+			user);
+	}
+
+	private Optional<CouponTransactionHistory> findCouponTransactionHistory(Coupon coupon, User user) {
+		return couponTransactionHistoryRepository.findByCouponAndUser(coupon, user);
+	}
+
+	private Coupon findCoupon(Long couponId) {
+		return couponRepository.findById(couponId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+	}
+
+	private User findUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND));
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyService.java
@@ -1,11 +1,7 @@
 package com.coffee_shop.coffeeshop.service.coupon.apply;
 
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
-import com.coffee_shop.coffeeshop.service.coupon.dto.response.CouponApplyResponse;
 
 public interface CouponApplyService {
-	CouponApplyResponse isCouponIssued(Long userId, Long couponId);
-
 	void applyCoupon(CouponApplyServiceRequest request);
-
 }

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyServiceImpl.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyServiceImpl.java
@@ -1,23 +1,19 @@
 package com.coffee_shop.coffeeshop.service.coupon.apply;
 
-import java.util.Optional;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
 import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
-import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueStatus;
-import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
 import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponMessageQProducer;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueFailHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.exception.ErrorCode;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
-import com.coffee_shop.coffeeshop.service.coupon.dto.response.CouponApplyResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -30,25 +26,7 @@ public class CouponApplyServiceImpl implements CouponApplyService {
 	private final CouponRepository couponRepository;
 	private final CouponMessageQProducer couponMessageQProducer;
 	private final CouponTransactionHistoryRepository couponTransactionHistoryRepository;
-
-	public CouponApplyResponse isCouponIssued(Long userId, Long couponId) {
-		User user = findUser(userId);
-		Coupon coupon = findCoupon(couponId);
-
-		Optional<CouponTransactionHistory> history = couponTransactionHistoryRepository.findByCouponAndUser(
-			coupon, user);
-
-		if (history.isPresent()) {
-			return CouponApplyResponse.of(CouponIssueStatus.SUCCESS);
-		}
-
-		try {
-			int position = couponMessageQProducer.getPosition(user, coupon);
-			return CouponApplyResponse.of(CouponIssueStatus.IN_PROGRESS, position);
-		} catch (BusinessException e) {
-			return CouponApplyResponse.of(CouponIssueStatus.FAILURE);
-		}
-	}
+	private final CouponIssueFailHistoryRepository couponIssueFailHistoryRepository;
 
 	public void applyCoupon(CouponApplyServiceRequest request) {
 		User user = findUser(request.getUserId());

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/RedisCouponApplyService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/apply/RedisCouponApplyService.java
@@ -1,25 +1,19 @@
 package com.coffee_shop.coffeeshop.service.coupon.apply;
 
-import java.util.Optional;
-
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
 import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
-import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueStatus;
-import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
 import com.coffee_shop.coffeeshop.domain.coupon.producer.RedisCouponProducer;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.AppliedUserRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueCountRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
-import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.exception.ErrorCode;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
-import com.coffee_shop.coffeeshop.service.coupon.dto.response.CouponApplyResponse;
 
 import lombok.RequiredArgsConstructor;
 
@@ -31,28 +25,8 @@ public class RedisCouponApplyService implements CouponApplyService {
 	private final UserRepository userRepository;
 	private final CouponRepository couponRepository;
 	private final RedisCouponProducer redisCouponProducer;
-	private final CouponTransactionHistoryRepository couponTransactionHistoryRepository;
 	private final CouponIssueCountRepository couponIssueCountRepository;
 	private final AppliedUserRepository appliedUserRepository;
-
-	public CouponApplyResponse isCouponIssued(Long userId, Long couponId) {
-		User user = findUser(userId);
-		Coupon coupon = findCoupon(couponId);
-
-		Optional<CouponTransactionHistory> history = couponTransactionHistoryRepository.findByCouponAndUser(
-			coupon, user);
-
-		if (history.isPresent()) {
-			return CouponApplyResponse.of(CouponIssueStatus.SUCCESS);
-		}
-
-		try {
-			int position = redisCouponProducer.getPosition(user, coupon);
-			return CouponApplyResponse.of(CouponIssueStatus.IN_PROGRESS, position);
-		} catch (BusinessException e) {
-			return CouponApplyResponse.of(CouponIssueStatus.FAILURE);
-		}
-	}
 
 	public void applyCoupon(CouponApplyServiceRequest request) {
 		User user = findUser(request.getUserId());

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/CouponIssueServiceImpl.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/CouponIssueServiceImpl.java
@@ -2,7 +2,7 @@ package com.coffee_shop.coffeeshop.service.coupon.issue;
 
 import java.time.LocalDateTime;
 
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
@@ -20,7 +20,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-@Component
+@Service
 public class CouponIssueServiceImpl {
 	private final UserRepository userRepository;
 	private final CouponRepository couponRepository;

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/RedisCouponIssueService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/RedisCouponIssueService.java
@@ -2,7 +2,7 @@ package com.coffee_shop.coffeeshop.service.coupon.issue;
 
 import java.time.LocalDateTime;
 
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
@@ -21,7 +21,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-@Component
+@Service
 public class RedisCouponIssueService {
 	private final UserRepository userRepository;
 	private final CouponRepository couponRepository;

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/CouponIssueFailHandlerImpl.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/CouponIssueFailHandlerImpl.java
@@ -16,16 +16,19 @@ import lombok.extern.slf4j.Slf4j;
 public class CouponIssueFailHandlerImpl {
 	private static final int MAX_FAIL_COUNT = 3;
 	private final MessageQ messageQ;
+	private final CouponIssueFailHistoryService couponIssueFailHistoryService;
 
 	public void handleFail(CouponApplication couponApplication, Exception exception) {
 		couponApplication.addException(exception);
 		couponApplication.increaseFailCount();
 
-		if (couponApplication.getFailCount() >= MAX_FAIL_COUNT) {
-			handleTooManyFails(couponApplication);
-		} else {
+		if (MAX_FAIL_COUNT > couponApplication.getFailCount()) {
 			messageQ.addFirst(couponApplication);
+			return;
 		}
+
+		handleTooManyFails(couponApplication);
+		couponIssueFailHistoryService.saveCouponFailHistory(couponApplication);
 	}
 
 	private void handleTooManyFails(CouponApplication couponApplication) {

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/CouponIssueFailHandlerImpl.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/CouponIssueFailHandlerImpl.java
@@ -2,7 +2,7 @@ package com.coffee_shop.coffeeshop.service.coupon.issue.fail;
 
 import java.util.List;
 
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
@@ -12,7 +12,7 @@ import lombok.extern.slf4j.Slf4j;
 
 @Slf4j
 @RequiredArgsConstructor
-@Component
+@Service
 public class CouponIssueFailHandlerImpl {
 	private static final int MAX_FAIL_COUNT = 3;
 	private final MessageQ messageQ;

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/CouponIssueFailHistoryService.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/CouponIssueFailHistoryService.java
@@ -1,0 +1,47 @@
+package com.coffee_shop.coffeeshop.service.coupon.issue.fail;
+
+import java.time.LocalDateTime;
+
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import com.coffee_shop.coffeeshop.common.exception.BusinessException;
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueFailHistory;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueFailHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.domain.user.UserRepository;
+import com.coffee_shop.coffeeshop.exception.ErrorCode;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
+
+import lombok.RequiredArgsConstructor;
+
+@RequiredArgsConstructor
+@Service
+public class CouponIssueFailHistoryService {
+	private final UserRepository userRepository;
+	private final CouponRepository couponRepository;
+	private final CouponIssueFailHistoryRepository couponIssueFailHistoryRepository;
+
+	@Transactional
+	public void saveCouponFailHistory(CouponApplication couponApplication) {
+		Coupon coupon = findCoupon(couponApplication.getCouponId());
+		User user = findUser(couponApplication.getUserId());
+
+		CouponIssueFailHistory history = CouponIssueFailHistory.of(user, coupon,
+			LocalDateTime.now());
+		couponIssueFailHistoryRepository.save(history);
+	}
+
+	private Coupon findCoupon(Long couponId) {
+		return couponRepository.findById(couponId)
+			.orElseThrow(
+				() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND, "Coupon Not Found, 쿠폰 ID : " + couponId));
+	}
+
+	private User findUser(Long userId) {
+		return userRepository.findById(userId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.ENTITY_NOT_FOUND, "User Not Found, 사용자 ID : " + userId));
+	}
+}

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/RedisCouponIssueFailHandler.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/RedisCouponIssueFailHandler.java
@@ -2,7 +2,7 @@ package com.coffee_shop.coffeeshop.service.coupon.issue.fail;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Service;
 
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponFailCountRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueRepository;
@@ -11,7 +11,7 @@ import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
 import lombok.RequiredArgsConstructor;
 
 @RequiredArgsConstructor
-@Component
+@Service
 public class RedisCouponIssueFailHandler {
 	private static final Logger log = LoggerFactory.getLogger(RedisCouponIssueFailHandler.class);
 	private static final int MAX_FAIL_COUNT = 3;

--- a/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/RedisCouponIssueFailHandler.java
+++ b/src/main/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/RedisCouponIssueFailHandler.java
@@ -15,18 +15,21 @@ import lombok.RequiredArgsConstructor;
 public class RedisCouponIssueFailHandler {
 	private static final Logger log = LoggerFactory.getLogger(RedisCouponIssueFailHandler.class);
 	private static final int MAX_FAIL_COUNT = 3;
+	private final CouponIssueFailHistoryService couponIssueFailHistoryService;
 	private final CouponIssueRepository couponIssueRepository;
 	private final CouponFailCountRepository couponFailCountRepository;
 
 	public void handleFail(CouponApplication couponApplication, Exception exception) {
 		Long failCount = couponFailCountRepository.increment(couponApplication.getUserId());
 
-		if (failCount >= MAX_FAIL_COUNT) {
-			log.warn("최대 실패 횟수 {}회를 초과하였습니다. 실패 횟수 : {}", MAX_FAIL_COUNT, failCount, exception);
-		} else {
+		if (MAX_FAIL_COUNT > failCount) {
 			log.warn("쿠폰 발급 실패 > 재시도 횟수 : {}, 사용자 ID : {}, 쿠폰 ID : {}", failCount, couponApplication.getUserId(),
 				couponApplication.getCouponId(), exception);
 			couponIssueRepository.add(couponApplication, System.currentTimeMillis());
+			return;
 		}
+
+		log.warn("최대 실패 횟수 {}회를 초과하였습니다. 실패 횟수 : {}", MAX_FAIL_COUNT, failCount, exception);
+		couponIssueFailHistoryService.saveCouponFailHistory(couponApplication);
 	}
 }

--- a/src/test/java/com/coffee_shop/coffeeshop/controller/RestDocsSupport.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/controller/RestDocsSupport.java
@@ -19,6 +19,7 @@ import com.coffee_shop.coffeeshop.controller.coupon.CouponApplyController;
 import com.coffee_shop.coffeeshop.controller.coupon.CouponController;
 import com.coffee_shop.coffeeshop.controller.item.ItemController;
 import com.coffee_shop.coffeeshop.service.cart.CartService;
+import com.coffee_shop.coffeeshop.service.coupon.CouponIssueStatusService;
 import com.coffee_shop.coffeeshop.service.coupon.CouponService;
 import com.coffee_shop.coffeeshop.service.coupon.apply.CouponApplyService;
 import com.coffee_shop.coffeeshop.service.item.ItemService;
@@ -50,6 +51,9 @@ public abstract class RestDocsSupport {
 
 	@MockBean
 	protected CouponApplyService couponApplyService;
+
+	@MockBean
+	protected CouponIssueStatusService couponIssueStatusService;
 
 	@BeforeEach
 	void setUp(WebApplicationContext webApplicationContext,

--- a/src/test/java/com/coffee_shop/coffeeshop/controller/coupon/api/CouponApplyControllerTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/controller/coupon/api/CouponApplyControllerTest.java
@@ -142,7 +142,7 @@ class CouponApplyControllerTest extends RestDocsSupport {
 			.position(-1)
 			.build();
 
-		when(couponApplyService.isCouponIssued(any(), any())).thenReturn(couponApplyResponse);
+		when(couponIssueStatusService.isCouponIssued(any(), any())).thenReturn(couponApplyResponse);
 
 		//when //then
 		mockMvc.perform(

--- a/src/test/java/com/coffee_shop/coffeeshop/controller/coupon/api/CouponIssueStatusControllerTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/controller/coupon/api/CouponIssueStatusControllerTest.java
@@ -1,0 +1,43 @@
+package com.coffee_shop.coffeeshop.controller.coupon.api;
+
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.*;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.MediaType;
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.coffee_shop.coffeeshop.controller.RestDocsSupport;
+import com.coffee_shop.coffeeshop.docs.coupon.CouponDocumentation;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueStatus;
+import com.coffee_shop.coffeeshop.service.coupon.dto.response.CouponApplyResponse;
+
+@ActiveProfiles("messageQ")
+class CouponIssueStatusControllerTest extends RestDocsSupport {
+	@DisplayName("쿠폰 발급 결과를 조회한다.")
+	@Test
+	void isIssuedCoupon() throws Exception {
+		//given
+		CouponApplyResponse couponApplyResponse = CouponApplyResponse.builder()
+			.couponIssueStatus(CouponIssueStatus.SUCCESS)
+			.position(-1)
+			.build();
+
+		when(couponIssueStatusService.isCouponIssued(any(), any())).thenReturn(couponApplyResponse);
+
+		//when //then
+		mockMvc.perform(
+				RestDocumentationRequestBuilders.get("/api/users/{userId}/coupons/{couponId}", 1L, 1L)
+					.contentType(MediaType.APPLICATION_JSON)
+			)
+			.andDo(print())
+			.andExpect(status().isOk())
+			.andExpect(jsonPath("$.code").value("OK"))
+			.andExpect(jsonPath("$.message").value("OK"))
+			.andDo(CouponDocumentation.isIssuedCoupon());
+	}
+}

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/MessageQCouponIssueStatusServiceTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/MessageQCouponIssueStatusServiceTest.java
@@ -1,0 +1,197 @@
+package com.coffee_shop.coffeeshop.service.coupon;
+
+import static com.coffee_shop.coffeeshop.domain.coupon.CouponType.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Queue;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueFailHistory;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueStatus;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
+import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
+import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponMessageQProducer;
+import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponProducer;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueFailHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.domain.user.UserRepository;
+import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
+import com.coffee_shop.coffeeshop.service.coupon.apply.CouponApplyServiceImpl;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
+import com.coffee_shop.coffeeshop.service.coupon.dto.response.CouponApplyResponse;
+
+@ActiveProfiles("messageQ")
+class MessageQCouponIssueStatusServiceTest extends IntegrationTestSupport {
+
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@Autowired
+	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
+
+	@Autowired
+	private CouponIssueFailHistoryRepository couponIssueFailHistoryRepository;
+
+	private CouponIssueStatusService couponIssueStatusService;
+
+	private CouponApplyServiceImpl couponApplyService;
+
+	private MessageQ messageQ;
+
+	private CouponProducer couponProducer;
+
+	@BeforeEach
+	void setUp() {
+		messageQ = new MessageQ();
+		CouponMessageQProducer couponMessageQProducer = new CouponMessageQProducer(messageQ);
+		couponApplyService = new CouponApplyServiceImpl(userRepository, couponRepository, couponMessageQProducer,
+			couponTransactionHistoryRepository, couponIssueFailHistoryRepository);
+		couponProducer = new CouponMessageQProducer(messageQ);
+		couponIssueStatusService = new CouponIssueStatusService(userRepository, couponRepository, couponProducer,
+			couponTransactionHistoryRepository, couponIssueFailHistoryRepository);
+	}
+
+	@AfterEach
+	void tearDown() {
+		couponTransactionHistoryRepository.deleteAllInBatch();
+		couponIssueFailHistoryRepository.deleteAllInBatch();
+		couponRepository.deleteAllInBatch();
+		userRepository.deleteAllInBatch();
+	}
+
+	@DisplayName("쿠폰 발급이 완료된다면 발급 결과 조회시 발급 결과는 성공, 대기 순번은 -1로 반환된다.")
+	@Test
+	void findPositionWhenIssueCouponSuccessfully() {
+		//given
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+		Coupon coupon = createCoupon(10, 0);
+		User user = createUser();
+
+		createCouponTransactionHistory(coupon, user, issueDateTime);
+
+		//when
+		CouponApplyResponse response = couponIssueStatusService.isCouponIssued(user.getId(), coupon.getId());
+
+		//then
+		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.SUCCESS);
+		assertThat(response.getPosition()).isEqualTo(-1);
+	}
+
+	@DisplayName("쿠폰 발급 실패한다면 발급 결과 조회시 발급 결과는 실패, 대기 순번은 -1로 반환된다.")
+	@Test
+	void findPositionWhenFailToIssueCoupon() {
+		//given
+		Coupon coupon = createCoupon(10, 0);
+		User user = createUser();
+
+		CouponIssueFailHistory couponIssueFailHistory = CouponIssueFailHistory.of(user, coupon, LocalDateTime.now());
+		couponIssueFailHistoryRepository.save(couponIssueFailHistory);
+
+		//when
+		CouponApplyResponse response = couponIssueStatusService.isCouponIssued(user.getId(), coupon.getId());
+
+		//then
+		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.FAILURE);
+		assertThat(response.getPosition()).isEqualTo(-1);
+	}
+
+	@DisplayName("쿠폰 발급중이라면 발급 결과 조회시 발급 결과는 발급중, 현재 대기열 순번이 반환된다.")
+	@Test
+	void findPositionWhenCouponIsBeingIssued() throws InterruptedException {
+		//given
+		int maxIssueCount = 10;
+		Coupon coupon = createCoupon(10, 0);
+
+		ExecutorService executorService = Executors.newFixedThreadPool(32);
+		CountDownLatch latch = new CountDownLatch(maxIssueCount);
+
+		int expectedPosition = 3;
+		Long expectedUserId = null;
+		Queue<Long> users = new ConcurrentLinkedDeque<>();
+
+		for (int i = 0; i < maxIssueCount; i++) {
+			User user = createUser();
+			users.add(user.getId());
+			if (i == expectedPosition - 1) {
+				expectedUserId = user.getId();
+			}
+		}
+
+		for (int i = 0; i < maxIssueCount; i++) {
+			executorService.submit(() -> {
+				try {
+					couponApplyService.applyCoupon(createRequest(users.remove(), coupon.getId()));
+				} catch (Exception e) {
+					e.printStackTrace();
+				} finally {
+					latch.countDown();
+				}
+			});
+			Thread.sleep(1000);
+		}
+
+		latch.await();
+
+		//when
+		CouponApplyResponse response = couponIssueStatusService.isCouponIssued(expectedUserId, coupon.getId());
+
+		//then
+		assertThat(messageQ.size()).isEqualTo(maxIssueCount);
+		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.IN_PROGRESS);
+		assertThat(response.getPosition()).isEqualTo(expectedPosition);
+	}
+
+	private CouponApplyServiceRequest createRequest(Long userId, Long couponId) {
+		return CouponApplyServiceRequest.builder()
+			.userId(userId)
+			.couponId(couponId)
+			.build();
+	}
+
+	private CouponTransactionHistory createCouponTransactionHistory(Coupon coupon, User user,
+		LocalDateTime issueDateTime) {
+		CouponTransactionHistory history = CouponTransactionHistory.builder()
+			.user(user)
+			.coupon(coupon)
+			.issueDateTime(issueDateTime)
+			.build();
+
+		return couponTransactionHistoryRepository.save(history);
+	}
+
+	private Coupon createCoupon(int maxIssueCount, int issuedCount) {
+		Coupon coupon = Coupon.builder()
+			.name("오픈기념 선착순 할인 쿠폰")
+			.type(AMOUNT)
+			.discountAmount(1000)
+			.minOrderAmount(4000)
+			.maxIssueCount(maxIssueCount)
+			.issuedCount(issuedCount)
+			.build();
+		return couponRepository.save(coupon);
+	}
+
+	private User createUser() {
+		User user = User.builder()
+			.name("우경서")
+			.build();
+		return userRepository.save(user);
+	}
+}

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/RedisCouponIssueStatusServiceTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/RedisCouponIssueStatusServiceTest.java
@@ -1,0 +1,198 @@
+package com.coffee_shop.coffeeshop.service.coupon;
+
+import static com.coffee_shop.coffeeshop.domain.coupon.CouponType.*;
+import static org.assertj.core.api.Assertions.*;
+
+import java.time.LocalDateTime;
+import java.util.Queue;
+import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.ActiveProfiles;
+
+import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueFailHistory;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueStatus;
+import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
+import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponProducer;
+import com.coffee_shop.coffeeshop.domain.coupon.producer.RedisCouponProducer;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueFailHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHistoryRepository;
+import com.coffee_shop.coffeeshop.domain.user.User;
+import com.coffee_shop.coffeeshop.domain.user.UserRepository;
+import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
+import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
+import com.coffee_shop.coffeeshop.service.coupon.dto.response.CouponApplyResponse;
+
+@ActiveProfiles("messageQ")
+class RedisCouponIssueStatusServiceTest extends IntegrationTestSupport {
+	@Autowired
+	private UserRepository userRepository;
+
+	@Autowired
+	private CouponRepository couponRepository;
+
+	@Autowired
+	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
+
+	@Autowired
+	private CouponIssueFailHistoryRepository couponIssueFailHistoryRepository;
+
+	@Autowired
+	private CouponIssueRepository couponIssueRepository;
+
+	@Autowired
+	private RedisTemplate<String, Long> redisTemplate;
+
+	private CouponIssueStatusService couponIssueStatusService;
+
+	private CouponProducer couponProducer;
+
+	@BeforeEach
+	void setUp() {
+		couponProducer = new RedisCouponProducer(couponIssueRepository);
+		couponIssueStatusService = new CouponIssueStatusService(userRepository, couponRepository, couponProducer,
+			couponTransactionHistoryRepository, couponIssueFailHistoryRepository);
+	}
+
+	@AfterEach
+	void tearDown() {
+		couponTransactionHistoryRepository.deleteAllInBatch();
+		couponIssueFailHistoryRepository.deleteAllInBatch();
+		couponRepository.deleteAllInBatch();
+		userRepository.deleteAllInBatch();
+		clearAll();
+	}
+
+	@DisplayName("쿠폰 발급이 완료된다면 발급 결과 조회시 발급 결과는 성공, 대기 순번은 -1로 반환된다.")
+	@Test
+	void findPositionWhenIssueCouponSuccessfully() {
+		//given
+		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
+		Coupon coupon = createCoupon(10, 0);
+		User user = createUser();
+
+		createCouponTransactionHistory(coupon, user, issueDateTime);
+
+		//when
+		CouponApplyResponse response = couponIssueStatusService.isCouponIssued(user.getId(), coupon.getId());
+
+		//then
+		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.SUCCESS);
+		assertThat(response.getPosition()).isEqualTo(-1);
+	}
+
+	@DisplayName("쿠폰 발급 실패한다면 발급 결과 조회시 발급 결과는 실패, 대기 순번은 -1로 반환된다.")
+	@Test
+	void findPositionWhenFailToIssueCoupon() {
+		//given
+		Coupon coupon = createCoupon(10, 0);
+		User user = createUser();
+
+		CouponIssueFailHistory couponIssueFailHistory = CouponIssueFailHistory.of(user, coupon, LocalDateTime.now());
+		couponIssueFailHistoryRepository.save(couponIssueFailHistory);
+
+		//when
+		CouponApplyResponse response = couponIssueStatusService.isCouponIssued(user.getId(), coupon.getId());
+
+		//then
+		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.FAILURE);
+		assertThat(response.getPosition()).isEqualTo(-1);
+	}
+
+	@DisplayName("쿠폰 발급중이라면 발급 결과 조회시 발급 결과는 발급중, 현재 대기열 순번이 반환된다.")
+	@Test
+	void findPositionWhenCouponIsBeingIssued() throws InterruptedException {
+		//given
+		int maxIssueCount = 5;
+		Coupon coupon = createCoupon(10, 0);
+
+		ExecutorService executorService = Executors.newFixedThreadPool(32);
+		CountDownLatch latch = new CountDownLatch(maxIssueCount);
+
+		int expectedPosition = 3;
+		Long expectedUserId = null;
+		Queue<User> users = new ConcurrentLinkedDeque<>();
+
+		for (int i = 0; i < maxIssueCount; i++) {
+			User user = createUser();
+			users.add(user);
+			if (i == expectedPosition - 1) {
+				expectedUserId = user.getId();
+			}
+		}
+
+		for (int i = 0; i < maxIssueCount; i++) {
+			executorService.submit(() -> {
+				try {
+					couponIssueRepository.add(CouponApplication.of(users.remove(), coupon), System.currentTimeMillis());
+				} catch (Exception e) {
+					e.printStackTrace();
+				} finally {
+					latch.countDown();
+				}
+
+			});
+
+			Thread.sleep(500);
+		}
+
+		latch.await();
+
+		//when
+		CouponApplyResponse response = couponIssueStatusService.isCouponIssued(expectedUserId, coupon.getId());
+
+		//then
+		assertThat(couponIssueRepository.count()).isEqualTo(maxIssueCount);
+		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.IN_PROGRESS);
+		assertThat(response.getPosition()).isEqualTo(expectedPosition);
+	}
+
+	private Coupon createCoupon(int maxIssueCount, int issuedCount) {
+		Coupon coupon = Coupon.builder()
+			.name("오픈기념 선착순 할인 쿠폰")
+			.type(AMOUNT)
+			.discountAmount(1000)
+			.minOrderAmount(4000)
+			.maxIssueCount(maxIssueCount)
+			.issuedCount(issuedCount)
+			.build();
+		return couponRepository.save(coupon);
+	}
+
+	private User createUser() {
+		User user = User.builder()
+			.name("우경서")
+			.build();
+		return userRepository.save(user);
+	}
+
+	private void clearAll() {
+		Set<String> keys = redisTemplate.keys("*");
+		if (keys != null && !keys.isEmpty()) {
+			redisTemplate.delete(keys);
+		}
+	}
+
+	private CouponTransactionHistory createCouponTransactionHistory(Coupon coupon, User user,
+		LocalDateTime issueDateTime) {
+		CouponTransactionHistory history = CouponTransactionHistory.builder()
+			.user(user)
+			.coupon(coupon)
+			.issueDateTime(issueDateTime)
+			.build();
+
+		return couponTransactionHistoryRepository.save(history);
+	}
+}

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyServiceImplTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/apply/CouponApplyServiceImplTest.java
@@ -15,23 +15,20 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.test.context.ActiveProfiles;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
 import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
-import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueStatus;
 import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
 import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
-import com.coffee_shop.coffeeshop.domain.coupon.consumer.CouponMessageQConsumer;
 import com.coffee_shop.coffeeshop.domain.coupon.producer.CouponMessageQProducer;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueFailHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
-import com.coffee_shop.coffeeshop.service.coupon.dto.response.CouponApplyResponse;
 
 @ActiveProfiles("messageQ")
 class CouponApplyServiceImplTest extends IntegrationTestSupport {
@@ -45,8 +42,8 @@ class CouponApplyServiceImplTest extends IntegrationTestSupport {
 	@Autowired
 	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
 
-	@MockBean
-	private CouponMessageQConsumer couponMessageQConsumer;
+	@Autowired
+	private CouponIssueFailHistoryRepository couponIssueFailHistoryRepository;
 
 	private CouponApplyServiceImpl couponApplyService;
 	private MessageQ messageQ;
@@ -56,12 +53,13 @@ class CouponApplyServiceImplTest extends IntegrationTestSupport {
 		messageQ = new MessageQ();
 		CouponMessageQProducer couponMessageQProducer = new CouponMessageQProducer(messageQ);
 		couponApplyService = new CouponApplyServiceImpl(userRepository, couponRepository, couponMessageQProducer,
-			couponTransactionHistoryRepository);
+			couponTransactionHistoryRepository, couponIssueFailHistoryRepository);
 	}
 
 	@AfterEach
 	void tearDown() {
 		couponTransactionHistoryRepository.deleteAllInBatch();
+		couponIssueFailHistoryRepository.deleteAllInBatch();
 		couponRepository.deleteAllInBatch();
 		userRepository.deleteAllInBatch();
 	}
@@ -144,85 +142,6 @@ class CouponApplyServiceImplTest extends IntegrationTestSupport {
 			() -> couponApplyService.applyCoupon(createRequest(user.getId(), coupon.getId())))
 			.isInstanceOf(BusinessException.class)
 			.hasMessage("이미 발급된 쿠폰입니다. 사용자 ID = " + user.getId() + ", 사용자 이름 = " + user.getName());
-	}
-
-	@DisplayName("쿠폰 발급이 완료된다면 발급 결과 조회시 발급 결과는 성공, 대기 순번은 -1로 반환된다.")
-	@Test
-	void findPositionWhenIssueCouponSuccessfully() {
-		//given
-		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
-		Coupon coupon = createCoupon(10, 0);
-		User user = createUser();
-
-		createCouponTransactionHistory(coupon, user, issueDateTime);
-
-		//when
-		CouponApplyResponse response = couponApplyService.isCouponIssued(user.getId(), coupon.getId());
-
-		//then
-		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.SUCCESS);
-		assertThat(response.getPosition()).isEqualTo(-1);
-	}
-
-	@DisplayName("쿠폰 발급 실패한다면 발급 결과 조회시 발급 결과는 실패, 대기 순번은 -1로 반환된다.")
-	@Test
-	void findPositionWhenFailToIssueCoupon() {
-		//given
-		Coupon coupon = createCoupon(10, 0);
-		User user = createUser();
-
-		//when
-		CouponApplyResponse response = couponApplyService.isCouponIssued(user.getId(), coupon.getId());
-
-		//then
-		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.FAILURE);
-		assertThat(response.getPosition()).isEqualTo(-1);
-	}
-
-	@DisplayName("쿠폰 발급중이라면 발급 결과 조회시 발급 결과는 발급중, 현재 대기열 순번이 반환된다.")
-	@Test
-	void findPositionWhenCouponIsBeingIssued() throws InterruptedException {
-		//given
-		int maxIssueCount = 10;
-		Coupon coupon = createCoupon(10, 0);
-
-		ExecutorService executorService = Executors.newFixedThreadPool(32);
-		CountDownLatch latch = new CountDownLatch(maxIssueCount);
-
-		int expectedPosition = 3;
-		Long expectedUserId = null;
-		Queue<Long> users = new ConcurrentLinkedDeque<>();
-
-		for (int i = 0; i < maxIssueCount; i++) {
-			User user = createUser();
-			users.add(user.getId());
-			if (i == expectedPosition - 1) {
-				expectedUserId = user.getId();
-			}
-		}
-
-		for (int i = 0; i < maxIssueCount; i++) {
-			executorService.submit(() -> {
-				try {
-					couponApplyService.applyCoupon(createRequest(users.remove(), coupon.getId()));
-				} catch (Exception e) {
-					e.printStackTrace();
-				} finally {
-					latch.countDown();
-				}
-			});
-			Thread.sleep(1000);
-		}
-
-		latch.await();
-
-		//when
-		CouponApplyResponse response = couponApplyService.isCouponIssued(expectedUserId, coupon.getId());
-
-		//then
-		assertThat(messageQ.size()).isEqualTo(maxIssueCount);
-		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.IN_PROGRESS);
-		assertThat(response.getPosition()).isEqualTo(expectedPosition);
 	}
 
 	private CouponApplyServiceRequest createRequest(Long userId, Long couponId) {

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/apply/RedisCouponApplyServiceTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/apply/RedisCouponApplyServiceTest.java
@@ -5,7 +5,6 @@ import static java.util.concurrent.TimeUnit.*;
 import static org.assertj.core.api.Assertions.*;
 import static org.awaitility.Awaitility.*;
 
-import java.time.LocalDateTime;
 import java.util.Queue;
 import java.util.Set;
 import java.util.concurrent.ConcurrentLinkedDeque;
@@ -22,19 +21,16 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.coffee_shop.coffeeshop.common.exception.BusinessException;
 import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
-import com.coffee_shop.coffeeshop.domain.coupon.CouponIssueStatus;
-import com.coffee_shop.coffeeshop.domain.coupon.CouponTransactionHistory;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.AppliedUserRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueCountRepository;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueFailHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.user.User;
 import com.coffee_shop.coffeeshop.domain.user.UserRepository;
 import com.coffee_shop.coffeeshop.service.IntegrationTestSupport;
-import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplication;
 import com.coffee_shop.coffeeshop.service.coupon.dto.request.CouponApplyServiceRequest;
-import com.coffee_shop.coffeeshop.service.coupon.dto.response.CouponApplyResponse;
 
 @ActiveProfiles("redis")
 class RedisCouponApplyServiceTest extends IntegrationTestSupport {
@@ -46,6 +42,9 @@ class RedisCouponApplyServiceTest extends IntegrationTestSupport {
 
 	@Autowired
 	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
+
+	@Autowired
+	private CouponIssueFailHistoryRepository couponIssueFailHistoryRepository;
 
 	@Autowired
 	private CouponIssueRepository couponIssueRepository;
@@ -65,6 +64,7 @@ class RedisCouponApplyServiceTest extends IntegrationTestSupport {
 	@AfterEach
 	void tearDown() {
 		couponTransactionHistoryRepository.deleteAllInBatch();
+		couponIssueFailHistoryRepository.deleteAllInBatch();
 		couponRepository.deleteAllInBatch();
 		userRepository.deleteAllInBatch();
 		clearAll();
@@ -155,101 +155,11 @@ class RedisCouponApplyServiceTest extends IntegrationTestSupport {
 			.hasMessage("이미 발급된 쿠폰입니다. 사용자 ID = " + user.getId() + ", 사용자 이름 = " + user.getName());
 	}
 
-	@DisplayName("쿠폰 발급이 완료된다면 발급 결과 조회시 발급 결과는 성공, 대기 순번은 -1로 반환된다.")
-	@Test
-	void findPositionWhenIssueCouponSuccessfully() {
-		//given
-		LocalDateTime issueDateTime = LocalDateTime.of(2024, 8, 30, 0, 0);
-		Coupon coupon = createCoupon(10, 0);
-		User user = createUser();
-
-		createCouponTransactionHistory(coupon, user, issueDateTime);
-
-		//when
-		CouponApplyResponse response = redisCouponApplyService.isCouponIssued(user.getId(), coupon.getId());
-
-		//then
-		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.SUCCESS);
-		assertThat(response.getPosition()).isEqualTo(-1);
-	}
-
-	@DisplayName("쿠폰 발급 실패한다면 발급 결과 조회시 발급 결과는 실패, 대기 순번은 -1로 반환된다.")
-	@Test
-	void findPositionWhenFailToIssueCoupon() {
-		//given
-		Coupon coupon = createCoupon(10, 0);
-		User user = createUser();
-
-		//when
-		CouponApplyResponse response = redisCouponApplyService.isCouponIssued(user.getId(), coupon.getId());
-
-		//then
-		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.FAILURE);
-		assertThat(response.getPosition()).isEqualTo(-1);
-	}
-
-	@DisplayName("쿠폰 발급중이라면 발급 결과 조회시 발급 결과는 발급중, 현재 대기열 순번이 반환된다.")
-	@Test
-	void findPositionWhenCouponIsBeingIssued() throws InterruptedException {
-		//given
-		int maxIssueCount = 10;
-		Coupon coupon = createCoupon(10, 0);
-
-		ExecutorService executorService = Executors.newFixedThreadPool(32);
-		CountDownLatch latch = new CountDownLatch(maxIssueCount);
-
-		int expectedPosition = 3;
-		Long expectedUserId = null;
-		Queue<User> users = new ConcurrentLinkedDeque<>();
-
-		for (int i = 0; i < maxIssueCount; i++) {
-			User user = createUser();
-			users.add(user);
-			if (i == expectedPosition - 1) {
-				expectedUserId = user.getId();
-			}
-		}
-
-		for (int i = 0; i < maxIssueCount; i++) {
-			executorService.submit(() -> {
-				try {
-					couponIssueRepository.add(CouponApplication.of(users.remove(), coupon), 1731488205);
-				} catch (Exception e) {
-					e.printStackTrace();
-				} finally {
-					latch.countDown();
-				}
-
-			});
-		}
-
-		latch.await();
-
-		//when
-		CouponApplyResponse response = redisCouponApplyService.isCouponIssued(expectedUserId, coupon.getId());
-
-		//then
-		assertThat(couponIssueRepository.count()).isEqualTo(maxIssueCount);
-		assertThat(response.getCouponIssueStatus()).isEqualTo(CouponIssueStatus.IN_PROGRESS);
-		assertThat(response.getPosition()).isEqualTo(expectedPosition);
-	}
-
 	private CouponApplyServiceRequest createRequest(Long userId, Long couponId) {
 		return CouponApplyServiceRequest.builder()
 			.userId(userId)
 			.couponId(couponId)
 			.build();
-	}
-
-	private CouponTransactionHistory createCouponTransactionHistory(Coupon coupon, User user,
-		LocalDateTime issueDateTime) {
-		CouponTransactionHistory history = CouponTransactionHistory.builder()
-			.user(user)
-			.coupon(coupon)
-			.issueDateTime(issueDateTime)
-			.build();
-
-		return couponTransactionHistoryRepository.save(history);
 	}
 
 	private Coupon createCoupon(int maxIssueCount, int issuedCount) {

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/CouponIssueFailHandlerImplTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/CouponIssueFailHandlerImplTest.java
@@ -24,6 +24,7 @@ import org.springframework.test.context.ActiveProfiles;
 
 import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
 import com.coffee_shop.coffeeshop.domain.coupon.MessageQ;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueFailHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.user.User;
@@ -50,6 +51,9 @@ class CouponIssueFailHandlerImplTest extends IntegrationTestSupport {
 	@Autowired
 	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
 
+	@Autowired
+	private CouponIssueFailHistoryRepository couponIssueFailHistoryRepository;
+
 	@SpyBean
 	private CouponIssueServiceImpl couponIssueService;
 
@@ -58,6 +62,7 @@ class CouponIssueFailHandlerImplTest extends IntegrationTestSupport {
 	@AfterEach
 	void tearDown() {
 		couponTransactionHistoryRepository.deleteAllInBatch();
+		couponIssueFailHistoryRepository.deleteAllInBatch();
 		couponRepository.deleteAllInBatch();
 		userRepository.deleteAllInBatch();
 	}
@@ -85,6 +90,7 @@ class CouponIssueFailHandlerImplTest extends IntegrationTestSupport {
 			.atMost(2, SECONDS)
 			.untilAsserted(() -> {
 				assertThat(couponTransactionHistoryRepository.findAll()).hasSize(0);
+				assertThat(couponIssueFailHistoryRepository.findAll()).hasSize(1);
 
 				int expectedIssuedCount = couponRepository.findById(coupon.getId()).get().getIssuedCount();
 				assertThat(expectedIssuedCount).isEqualTo(0);
@@ -223,6 +229,7 @@ class CouponIssueFailHandlerImplTest extends IntegrationTestSupport {
 			.atMost(4, SECONDS)
 			.untilAsserted(() -> {
 				assertThat(couponTransactionHistoryRepository.findAll()).hasSize(maxIssueCount - 1);
+				assertThat(couponIssueFailHistoryRepository.findAll()).hasSize(1);
 
 				List<Coupon> coupons = couponRepository.findAll();
 				assertThat(coupons.get(0).getIssuedCount()).isEqualTo(maxIssueCount - 1);

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/CouponIssueFailHandlerImplTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/CouponIssueFailHandlerImplTest.java
@@ -226,7 +226,7 @@ class CouponIssueFailHandlerImplTest extends IntegrationTestSupport {
 
 		//then
 		await()
-			.atMost(4, SECONDS)
+			.atMost(5, SECONDS)
 			.untilAsserted(() -> {
 				assertThat(couponTransactionHistoryRepository.findAll()).hasSize(maxIssueCount - 1);
 				assertThat(couponIssueFailHistoryRepository.findAll()).hasSize(1);

--- a/src/test/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/RedisCouponIssueFailHandlerTest.java
+++ b/src/test/java/com/coffee_shop/coffeeshop/service/coupon/issue/fail/RedisCouponIssueFailHandlerTest.java
@@ -23,6 +23,7 @@ import org.springframework.boot.test.mock.mockito.SpyBean;
 import org.springframework.data.redis.core.RedisTemplate;
 
 import com.coffee_shop.coffeeshop.domain.coupon.Coupon;
+import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueFailHistoryRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponIssueRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponRepository;
 import com.coffee_shop.coffeeshop.domain.coupon.repository.CouponTransactionHistoryRepository;
@@ -48,6 +49,9 @@ class RedisCouponIssueFailHandlerTest extends IntegrationTestSupport {
 	private CouponTransactionHistoryRepository couponTransactionHistoryRepository;
 
 	@Autowired
+	private CouponIssueFailHistoryRepository couponIssueFailHistoryRepository;
+
+	@Autowired
 	private CouponIssueRepository couponIssueRepository;
 
 	@Autowired
@@ -61,6 +65,7 @@ class RedisCouponIssueFailHandlerTest extends IntegrationTestSupport {
 	@AfterEach
 	void tearDown() {
 		couponTransactionHistoryRepository.deleteAllInBatch();
+		couponIssueFailHistoryRepository.deleteAllInBatch();
 		couponRepository.deleteAllInBatch();
 		userRepository.deleteAllInBatch();
 		clearAll();
@@ -88,6 +93,8 @@ class RedisCouponIssueFailHandlerTest extends IntegrationTestSupport {
 		Thread.sleep(3000);
 
 		assertThat(couponTransactionHistoryRepository.findAll()).hasSize(0);
+		assertThat(couponIssueFailHistoryRepository.findAll()).hasSize(1);
+
 		assertTrue(couponIssueRepository.isEmpty());
 
 		List<ILoggingEvent> testLogs = listAppender.list;
@@ -149,6 +156,8 @@ class RedisCouponIssueFailHandlerTest extends IntegrationTestSupport {
 		Thread.sleep(4000);
 
 		assertThat(couponTransactionHistoryRepository.findAll()).hasSize(maxIssueCount - 1);
+		assertThat(couponIssueFailHistoryRepository.findAll()).hasSize(1);
+
 		assertTrue(couponIssueRepository.isEmpty());
 
 		List<ILoggingEvent> testLogs = listAppender.list;


### PR DESCRIPTION
## 쿠폰 발급 실패 이력 저장 로직 추가
### 구현 배경
- 현재 코드에서는 대기열에서 쿠폰 신청 건을 꺼내 발급을 진행 중일 때, 대기열 위치 조회 API를 호출하면 해당 신청 건을 대기열에서 찾을 수 없어 실패로 반환됩니다.
- 이로 인해 프론트엔드에서는 요청이 실패한 것으로 인식하고, 대기열 위치 조회 API를 재호출하지 않게 되어 문제가 발생합니다.
- 위와 같은 상황과 내부 시스템 오류로 인한 실패를 구분하기 위해 실패 이력 저장 로직을 추가했고 대기열 위치 조회 API가 내부 오류로 실패했을 때만 실패로 반환하도록 개선하였습니다.
- 실패 이력을 별도로 확인하여 추후 별도 발급 처리 시에도 유용하게 활용할 수 있습니다.
### 구현 내용
- 쿠폰 실패 이력 도메인을 추가했고 발급 실패시 실패 이력을 저장하도록 추가했습니다.
- 쿠폰 대기열 조회 로직 서비스를 별도로 분리했습니다.